### PR TITLE
Add basic target groups api

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -224,6 +224,16 @@ type PaginatedProducts {
 type BrevoContactAttributes {
   LASTNAME: String!
   FIRSTNAME: String!
+  SALUTATION: BrevoContactSalutation
+}
+
+enum BrevoContactSalutation {
+  MALE
+  FEMALE
+}
+
+type BrevoContactFilterAttributes {
+  SALUTATION: [BrevoContactSalutation!]
 }
 
 type DamFolder {
@@ -375,6 +385,24 @@ type PaginatedEmailCampaigns {
   totalCount: Int!
 }
 
+type TargetGroup implements DocumentInterface {
+  id: ID!
+  updatedAt: DateTime!
+  createdAt: DateTime!
+  title: String!
+  isMainList: Boolean!
+  brevoId: Int!
+  totalSubscribers: Int!
+  totalContactsBlocked: Int!
+  scope: EmailCampaignContentScope!
+  filters: BrevoContactFilterAttributes
+}
+
+type PaginatedTargetGroups {
+  nodes: [TargetGroup!]!
+  totalCount: Int!
+}
+
 input PageTreeNodeScopeInput {
   domain: String!
   language: String!
@@ -383,6 +411,11 @@ input PageTreeNodeScopeInput {
 input BrevoContactAttributesInput {
   LASTNAME: String!
   FIRSTNAME: String!
+  SALUTATION: BrevoContactSalutation
+}
+
+input BrevoContactFilterAttributesInput {
+  SALUTATION: [BrevoContactSalutation!]
 }
 
 input EmailCampaignContentScopeInput {
@@ -425,6 +458,8 @@ type Query {
   brevoContacts(offset: Int! = 0, limit: Int! = 25, email: String): PaginatedBrevoContacts!
   emailCampaign(id: ID!): EmailCampaign!
   emailCampaigns(scope: EmailCampaignContentScopeInput!, search: String, filter: EmailCampaignFilter, sort: [EmailCampaignSort!], offset: Int! = 0, limit: Int! = 25): PaginatedEmailCampaigns!
+  targetGroup(id: ID!): TargetGroup!
+  targetGroups(scope: EmailCampaignContentScopeInput!, search: String, filter: TargetGroupFilter, sort: [TargetGroupSort!], offset: Int! = 0, limit: Int! = 25): PaginatedTargetGroups!
 }
 
 enum SortDirection {
@@ -574,6 +609,25 @@ enum EmailCampaignSortField {
   scheduledAt
 }
 
+input TargetGroupFilter {
+  createdAt: DateFilter
+  updatedAt: DateFilter
+  title: StringFilter
+  and: [TargetGroupFilter!]
+  or: [TargetGroupFilter!]
+}
+
+input TargetGroupSort {
+  field: TargetGroupSortField!
+  direction: SortDirection! = ASC
+}
+
+enum TargetGroupSortField {
+  createdAt
+  updatedAt
+  title
+}
+
 type Mutation {
   currentUserSignOut: String!
   createBuilds(input: CreateBuildsInput!): Boolean!
@@ -613,6 +667,9 @@ type Mutation {
   createEmailCampaign(scope: EmailCampaignContentScopeInput!, input: EmailCampaignInput!): EmailCampaign!
   updateEmailCampaign(id: ID!, input: EmailCampaignInput!, lastUpdatedAt: DateTime): EmailCampaign!
   deleteEmailCampaign(id: ID!): Boolean!
+  createTargetGroup(scope: EmailCampaignContentScopeInput!, input: TargetGroupInput!): TargetGroup!
+  updateTargetGroup(id: ID!, input: TargetGroupInput!, lastUpdatedAt: DateTime): TargetGroup!
+  deleteTargetGroup(id: ID!): Boolean!
 }
 
 input CreateBuildsInput {
@@ -751,3 +808,8 @@ input EmailCampaignInput {
 
 """EmailCampaignContent root block input"""
 scalar EmailCampaignContentBlockInput @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
+
+input TargetGroupInput {
+  title: String!
+  filters: BrevoContactFilterAttributesInput
+}

--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -32,7 +32,7 @@ import { Request } from "express";
 
 import { AuthModule } from "./auth/auth.module";
 import { AuthLocalModule } from "./auth/auth-local.module";
-import { BrevoContactAttributes } from "./brevo-contact/dto/brevo-contact-attributes";
+import { BrevoContactAttributes, BrevoContactFilterAttributes } from "./brevo-contact/dto/brevo-contact-attributes";
 import { Config } from "./config/config";
 import { ConfigModule } from "./config/config.module";
 import { DamFile } from "./dam/entities/dam-file.entity";
@@ -132,6 +132,7 @@ export class AppModule {
                     brevo: {
                         apiKey: config.brevo.apiKey,
                         BrevoContactAttributes,
+                        BrevoContactFilterAttributes,
                         doubleOptInTemplateId: config.brevo.doubleOptInTemplateId,
                         allowedRedirectUrl: config.brevo.allowedRedirectUrl,
                         sender: {

--- a/demo/api/src/brevo-contact/dto/brevo-contact-attributes.ts
+++ b/demo/api/src/brevo-contact/dto/brevo-contact-attributes.ts
@@ -1,6 +1,9 @@
 import { IsUndefinable } from "@comet/cms-api";
+import { Embeddable, Enum } from "@mikro-orm/core";
 import { Field, InputType, ObjectType } from "@nestjs/graphql";
-import { IsNotEmpty, IsString } from "class-validator";
+import { IsEnum, IsNotEmpty, IsString } from "class-validator";
+
+import { BrevoContactSalutation } from "./brevo-contact.enums";
 
 @ObjectType()
 @InputType("BrevoContactAttributesInput")
@@ -14,4 +17,20 @@ export class BrevoContactAttributes {
     @IsString()
     @Field()
     FIRSTNAME: string;
+
+    @Field(() => BrevoContactSalutation, { nullable: true })
+    @IsEnum(BrevoContactSalutation)
+    @IsUndefinable()
+    SALUTATION?: BrevoContactSalutation;
+}
+
+@Embeddable()
+@ObjectType()
+@InputType("BrevoContactFilterAttributesInput")
+export class BrevoContactFilterAttributes {
+    @Field(() => [BrevoContactSalutation], { nullable: true })
+    @IsEnum(BrevoContactSalutation, { each: true })
+    @Enum({ items: () => BrevoContactSalutation, array: true })
+    @IsUndefinable()
+    SALUTATION?: BrevoContactSalutation[];
 }

--- a/demo/api/src/brevo-contact/dto/brevo-contact.enums.ts
+++ b/demo/api/src/brevo-contact/dto/brevo-contact.enums.ts
@@ -1,0 +1,10 @@
+import { registerEnumType } from "@nestjs/graphql";
+
+export enum BrevoContactSalutation {
+    MALE = "MALE",
+    FEMALE = "FEMALE",
+}
+
+registerEnumType(BrevoContactSalutation, {
+    name: "BrevoContactSalutation",
+});

--- a/demo/api/src/db/migrations/Migration20240115095733.ts
+++ b/demo/api/src/db/migrations/Migration20240115095733.ts
@@ -1,6 +1,7 @@
 import { Migration } from "@mikro-orm/migrations";
 
 export class Migration20240115095733 extends Migration {
+    // TODO: move to package
     async up(): Promise<void> {
         this.addSql(
             'create table "EmailCampaign" ("id" uuid not null, "createdAt" timestamp with time zone not null, "updatedAt" timestamp with time zone not null, "title" text not null, "subject" text not null, "scheduledAt" timestamp with time zone null, "scope_domain" text not null, "scope_language" text not null, "brevoId" int null, "contactList" uuid null, "content" json not null, constraint "Campaign_pkey" primary key ("id"));',

--- a/demo/api/src/db/migrations/Migration20240118144808.ts
+++ b/demo/api/src/db/migrations/Migration20240118144808.ts
@@ -1,0 +1,11 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20240118144808 extends Migration {
+    // TODO: move to package and make dynamic
+    async up(): Promise<void> {
+        this.addSql(
+            'create table "TargetGroup" ("id" uuid not null, "createdAt" timestamp with time zone not null, "updatedAt" timestamp with time zone not null, "title" text not null, "scope_domain" text not null, "scope_language" text not null, "brevoId" int not null, "filters_SALUTATION" text[] null, "isMainList" boolean);',
+        );
+        this.addSql('alter table "TargetGroup" add constraint "TargetGroup_pkey" primary key ("id");');
+    }
+}

--- a/packages/api/src/brevo-module.ts
+++ b/packages/api/src/brevo-module.ts
@@ -5,6 +5,7 @@ import { BrevoContactModule } from "./brevo-contact/brevo-contact.module";
 import { BrevoModuleConfig } from "./config/brevo-module.config";
 import { ConfigModule } from "./config/config.module";
 import { EmailCampaignModule } from "./email-campaign/email-campaign.module";
+import { TargetGroupModule } from "./target-group/target-group.module";
 
 @Global()
 @Module({})
@@ -16,6 +17,7 @@ export class BrevoModule {
                 BrevoApiModule,
                 BrevoContactModule.register({ BrevoContactAttributes: config.brevo.BrevoContactAttributes }),
                 EmailCampaignModule.register(config),
+                TargetGroupModule.register({ Scope: config.Scope, BrevoFilterAttributes: config.brevo.BrevoContactFilterAttributes }),
                 ConfigModule.forRoot(config),
             ],
             exports: [],

--- a/packages/api/src/config/brevo-module.config.ts
+++ b/packages/api/src/config/brevo-module.config.ts
@@ -1,12 +1,14 @@
 import { Block } from "@comet/blocks-api";
 import { Type } from "@nestjs/common";
+import { BrevoContactAttributesInterface, EmailCampaignScopeInterface } from "src/types";
 
-import { BrevoContactAttributesInterface, EmailCampaignScopeInterface } from "../types";
+import { BrevoContactFilterAttributesInterface } from "../types";
 
 export interface BrevoModuleConfig {
     brevo: {
         apiKey: string;
         BrevoContactAttributes?: Type<BrevoContactAttributesInterface>;
+        BrevoContactFilterAttributes?: Type<BrevoContactFilterAttributesInterface>;
         doubleOptInTemplateId: number;
         allowedRedirectUrl: string;
         sender: {

--- a/packages/api/src/target-group/dto/target-group-args.factory.ts
+++ b/packages/api/src/target-group/dto/target-group-args.factory.ts
@@ -1,0 +1,47 @@
+import { OffsetBasedPaginationArgs } from "@comet/cms-api";
+import { Type } from "@nestjs/common";
+import { ArgsType, Field } from "@nestjs/graphql";
+import { Type as TransformerType } from "class-transformer";
+import { IsOptional, IsString, ValidateNested } from "class-validator";
+import { EmailCampaignScopeInterface } from "src/types";
+
+import { TargetGroupFilter } from "./target-group.filter";
+import { TargetGroupSort } from "./target-group.sort";
+
+export interface PaginatedTargetGroupsArgsInterface extends OffsetBasedPaginationArgs {
+    scope: EmailCampaignScopeInterface;
+    search?: string;
+    filter?: TargetGroupFilter;
+    sort?: TargetGroupSort[];
+}
+
+export class TargetGroupArgsFactory {
+    static create({ Scope }: { Scope: Type<EmailCampaignScopeInterface> }) {
+        @ArgsType()
+        class TargetGroupArgs extends OffsetBasedPaginationArgs {
+            @Field(() => Scope)
+            @TransformerType(() => Scope)
+            @ValidateNested()
+            scope: EmailCampaignScopeInterface;
+
+            @Field({ nullable: true })
+            @IsOptional()
+            @IsString()
+            search?: string;
+
+            @Field(() => TargetGroupFilter, { nullable: true })
+            @ValidateNested()
+            @TransformerType(() => TargetGroupFilter)
+            @IsOptional()
+            filter?: TargetGroupFilter;
+
+            @Field(() => [TargetGroupSort], { nullable: true })
+            @ValidateNested({ each: true })
+            @TransformerType(() => TargetGroupSort)
+            @IsOptional()
+            sort?: TargetGroupSort[];
+        }
+
+        return TargetGroupArgs;
+    }
+}

--- a/packages/api/src/target-group/dto/target-group-input.factory.ts
+++ b/packages/api/src/target-group/dto/target-group-input.factory.ts
@@ -1,0 +1,48 @@
+import { IsUndefinable } from "@comet/cms-api";
+import { Type } from "@nestjs/common";
+import { Field, InputType } from "@nestjs/graphql";
+import { Type as TypeTransformer } from "class-transformer";
+import { IsNotEmpty, IsString, ValidateNested } from "class-validator";
+
+import { BrevoContactFilterAttributesInterface } from "../../types";
+
+export interface TargetGroupInputInterface {
+    title: string;
+    filters?: BrevoContactFilterAttributesInterface;
+}
+
+export class TargetGroupInputFactory {
+    static create({
+        BrevoFilterAttributes,
+    }: {
+        BrevoFilterAttributes?: Type<BrevoContactFilterAttributesInterface>;
+    }): Type<TargetGroupInputInterface> {
+        @InputType({
+            isAbstract: true,
+        })
+        class TargetGroupInputBase implements TargetGroupInputInterface {
+            @IsNotEmpty()
+            @IsString()
+            @Field()
+            title: string;
+        }
+
+        if (BrevoFilterAttributes) {
+            @InputType()
+            class TargetGroupInput extends TargetGroupInputBase {
+                @Field(() => BrevoFilterAttributes, { nullable: true })
+                @TypeTransformer(() => BrevoFilterAttributes)
+                @ValidateNested()
+                @IsUndefinable()
+                filters?: BrevoContactFilterAttributesInterface;
+            }
+
+            return TargetGroupInput;
+        }
+
+        @InputType()
+        class TargetGroupInput extends TargetGroupInputBase {}
+
+        return TargetGroupInput;
+    }
+}

--- a/packages/api/src/target-group/dto/target-group.filter.ts
+++ b/packages/api/src/target-group/dto/target-group.filter.ts
@@ -1,0 +1,37 @@
+import { DateFilter, StringFilter } from "@comet/cms-api";
+import { Field, InputType } from "@nestjs/graphql";
+import { Type } from "class-transformer";
+import { IsOptional, ValidateNested } from "class-validator";
+
+@InputType()
+export class TargetGroupFilter {
+    @Field(() => DateFilter, { nullable: true })
+    @ValidateNested()
+    @IsOptional()
+    @Type(() => DateFilter)
+    createdAt?: DateFilter;
+
+    @Field(() => DateFilter, { nullable: true })
+    @ValidateNested()
+    @IsOptional()
+    @Type(() => DateFilter)
+    updatedAt?: DateFilter;
+
+    @Field(() => StringFilter, { nullable: true })
+    @ValidateNested()
+    @IsOptional()
+    @Type(() => StringFilter)
+    title?: StringFilter;
+
+    @Field(() => [TargetGroupFilter], { nullable: true })
+    @Type(() => TargetGroupFilter)
+    @ValidateNested({ each: true })
+    @IsOptional()
+    and?: TargetGroupFilter[];
+
+    @Field(() => [TargetGroupFilter], { nullable: true })
+    @Type(() => TargetGroupFilter)
+    @ValidateNested({ each: true })
+    @IsOptional()
+    or?: TargetGroupFilter[];
+}

--- a/packages/api/src/target-group/dto/target-group.sort.ts
+++ b/packages/api/src/target-group/dto/target-group.sort.ts
@@ -1,0 +1,23 @@
+import { SortDirection } from "@comet/cms-api";
+import { Field, InputType, registerEnumType } from "@nestjs/graphql";
+import { IsEnum } from "class-validator";
+
+export enum TargetGroupSortField {
+    createdAt = "createdAt",
+    updatedAt = "updatedAt",
+    title = "title",
+}
+registerEnumType(TargetGroupSortField, {
+    name: "TargetGroupSortField",
+});
+
+@InputType()
+export class TargetGroupSort {
+    @Field(() => TargetGroupSortField)
+    @IsEnum(TargetGroupSortField)
+    field: TargetGroupSortField;
+
+    @Field(() => SortDirection, { defaultValue: SortDirection.ASC })
+    @IsEnum(SortDirection)
+    direction: SortDirection = SortDirection.ASC;
+}

--- a/packages/api/src/target-group/entity/target-group-entity.factory.ts
+++ b/packages/api/src/target-group/entity/target-group-entity.factory.ts
@@ -1,0 +1,95 @@
+import { DocumentInterface } from "@comet/cms-api";
+import { Embedded, Entity, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
+import { Type } from "@nestjs/common";
+import { Field, ID, Int, ObjectType } from "@nestjs/graphql";
+import { v4 } from "uuid";
+
+import { BrevoContactFilterAttributesInterface, EmailCampaignScopeInterface } from "../../types";
+
+export interface TargetGroupInterface {
+    [OptionalProps]?: "createdAt" | "updatedAt" | "totalSubscribers" | "totalContactsBlocked";
+    id: string;
+    createdAt: Date;
+    updatedAt: Date;
+    title: string;
+    isMainList: boolean;
+    brevoId: number;
+    totalSubscribers: number;
+    totalContactsBlocked: number;
+    scope: EmailCampaignScopeInterface;
+    filters?: BrevoContactFilterAttributesInterface;
+}
+
+export class TargetGroupEntityFactory {
+    static create({
+        Scope,
+        BrevoFilterAttributes,
+    }: {
+        Scope: Type<EmailCampaignScopeInterface>;
+        BrevoFilterAttributes?: Type<BrevoContactFilterAttributesInterface>;
+    }): Type<TargetGroupInterface> {
+        @Entity({ abstract: true })
+        @ObjectType({
+            implements: () => [DocumentInterface],
+            isAbstract: true,
+        })
+        class TargetGroupBase implements TargetGroupInterface, DocumentInterface {
+            [OptionalProps]?: "createdAt" | "updatedAt" | "totalSubscribers" | "totalContactsBlocked";
+
+            @PrimaryKey({ columnType: "uuid" })
+            @Field(() => ID)
+            id: string = v4();
+
+            @Property({ columnType: "timestamp with time zone" })
+            @Field()
+            createdAt: Date = new Date();
+
+            @Property({ columnType: "timestamp with time zone", onUpdate: () => new Date() })
+            @Field()
+            updatedAt: Date = new Date();
+
+            @Property({ columnType: "text" })
+            @Field()
+            title: string;
+
+            @Property({ columnType: "boolean" })
+            @Field()
+            isMainList: boolean;
+
+            @Property({ columnType: "int" })
+            @Field(() => Int)
+            brevoId: number;
+
+            @Field(() => Int)
+            totalSubscribers: number;
+
+            @Field(() => Int)
+            totalContactsBlocked: number;
+
+            @Embedded(() => Scope)
+            @Field(() => Scope)
+            scope: typeof Scope;
+        }
+        if (BrevoFilterAttributes) {
+            @Entity()
+            @ObjectType({
+                implements: () => [DocumentInterface],
+            })
+            class TargetGroup extends TargetGroupBase {
+                @Embedded(() => BrevoFilterAttributes, { nullable: true })
+                @Field(() => BrevoFilterAttributes, { nullable: true })
+                filters?: Type<BrevoContactFilterAttributesInterface>;
+            }
+
+            return TargetGroup;
+        }
+
+        @Entity()
+        @ObjectType({
+            implements: () => [DocumentInterface],
+        })
+        class TargetGroup extends TargetGroupBase {}
+
+        return TargetGroup;
+    }
+}

--- a/packages/api/src/target-group/target-group.module.ts
+++ b/packages/api/src/target-group/target-group.module.ts
@@ -1,0 +1,30 @@
+import { MikroOrmModule } from "@mikro-orm/nestjs";
+import { DynamicModule, Module, Type } from "@nestjs/common";
+
+import { BrevoModule } from "../brevo-module";
+import { ConfigModule } from "../config/config.module";
+import { BrevoContactFilterAttributesInterface, EmailCampaignScopeInterface } from "../types";
+import { TargetGroupInputFactory } from "./dto/target-group-input.factory";
+import { TargetGroupEntityFactory } from "./entity/target-group-entity.factory";
+import { createTargetGroupsResolver } from "./target-group.resolver";
+import { TargetGroupsService } from "./target-groups.service";
+
+interface TargetGroupModuleConfig {
+    Scope: Type<EmailCampaignScopeInterface>;
+    BrevoFilterAttributes?: Type<BrevoContactFilterAttributesInterface>;
+}
+
+@Module({})
+export class TargetGroupModule {
+    static register({ Scope, BrevoFilterAttributes }: TargetGroupModuleConfig): DynamicModule {
+        const TargetGroup = TargetGroupEntityFactory.create({ Scope, BrevoFilterAttributes });
+        const TargetGroupInput = TargetGroupInputFactory.create({ BrevoFilterAttributes });
+        const TargetGroupResolver = createTargetGroupsResolver({ TargetGroup, TargetGroupInput, Scope });
+
+        return {
+            module: TargetGroupModule,
+            imports: [ConfigModule, BrevoModule, MikroOrmModule.forFeature([TargetGroup])],
+            providers: [TargetGroupResolver, TargetGroupsService],
+        };
+    }
+}

--- a/packages/api/src/target-group/target-group.resolver.ts
+++ b/packages/api/src/target-group/target-group.resolver.ts
@@ -1,0 +1,116 @@
+import { PaginatedResponseFactory, SubjectEntity, validateNotModified } from "@comet/cms-api";
+import { EntityManager, EntityRepository, FindOptions, wrap } from "@mikro-orm/core";
+import { InjectRepository } from "@mikro-orm/nestjs";
+import { Type } from "@nestjs/common";
+import { Args, ArgsType, ID, Mutation, ObjectType, Query, Resolver } from "@nestjs/graphql";
+import { EmailCampaignScopeInterface } from "src/types";
+
+import { DynamicDtoValidationPipe } from "../validation/dynamic-dto-validation.pipe";
+import { TargetGroupArgsFactory } from "./dto/target-group-args.factory";
+import { TargetGroupInputInterface } from "./dto/target-group-input.factory";
+import { TargetGroupInterface } from "./entity/target-group-entity.factory";
+import { TargetGroupsService } from "./target-groups.service";
+
+export function createTargetGroupsResolver({
+    TargetGroup,
+    TargetGroupInput,
+    Scope,
+}: {
+    TargetGroup: Type<TargetGroupInterface>;
+    TargetGroupInput: Type<TargetGroupInputInterface>;
+    Scope: Type<EmailCampaignScopeInterface>;
+}): Type<unknown> {
+    @ObjectType()
+    class PaginatedTargetGroups extends PaginatedResponseFactory.create(TargetGroup) {}
+
+    @ArgsType()
+    class TargetGroupsArgs extends TargetGroupArgsFactory.create({ Scope }) {}
+
+    @Resolver(() => TargetGroup)
+    class TargetGroupResolver {
+        constructor(
+            private readonly targetGroupsService: TargetGroupsService,
+            private readonly entityManager: EntityManager,
+            @InjectRepository("TargetGroup") private readonly repository: EntityRepository<TargetGroupInterface>,
+        ) {}
+
+        @Query(() => TargetGroup)
+        @SubjectEntity(TargetGroup)
+        async targetGroup(@Args("id", { type: () => ID }) id: string): Promise<TargetGroupInterface> {
+            const targetGroup = await this.repository.findOneOrFail(id);
+            return targetGroup;
+        }
+
+        @Query(() => PaginatedTargetGroups)
+        async targetGroups(@Args() { search, filter, sort, offset, limit, scope }: TargetGroupsArgs): Promise<PaginatedTargetGroups> {
+            const where = this.targetGroupsService.getFindCondition({ search, filter });
+            where.scope = scope;
+
+            const options: FindOptions<TargetGroupInterface> = { offset, limit };
+
+            if (sort) {
+                options.orderBy = sort.map((sortItem) => {
+                    return {
+                        [sortItem.field]: sortItem.direction,
+                    };
+                });
+            }
+
+            const [entities, totalCount] = await this.repository.findAndCount(where, options);
+            return new PaginatedTargetGroups(entities, totalCount);
+        }
+
+        @Mutation(() => TargetGroup)
+        async createTargetGroup(
+            @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope))
+            scope: typeof Scope,
+            @Args("input", { type: () => TargetGroupInput }, new DynamicDtoValidationPipe(TargetGroupInput)) input: TargetGroupInputInterface,
+        ): Promise<TargetGroupInterface> {
+            const targetGroup = this.repository.create({
+                ...input,
+                scope,
+                // TODO: add correct brevo id
+                brevoId: 1,
+                // TODO: add correct logic for main list
+                isMainList: false,
+            });
+
+            await this.entityManager.flush();
+
+            return targetGroup;
+        }
+
+        @Mutation(() => TargetGroup)
+        @SubjectEntity(TargetGroup)
+        async updateTargetGroup(
+            @Args("id", { type: () => ID }) id: string,
+            @Args("input", { type: () => TargetGroupInput }, new DynamicDtoValidationPipe(TargetGroupInput)) input: TargetGroupInputInterface,
+            @Args("lastUpdatedAt", { type: () => Date, nullable: true }) lastUpdatedAt?: Date,
+        ): Promise<TargetGroupInterface> {
+            const targetGroup = await this.repository.findOneOrFail(id);
+
+            if (lastUpdatedAt) {
+                validateNotModified(targetGroup, lastUpdatedAt);
+            }
+
+            wrap(targetGroup).assign({
+                ...input,
+            });
+
+            await this.entityManager.flush();
+
+            return targetGroup;
+        }
+
+        @Mutation(() => Boolean)
+        @SubjectEntity(TargetGroup)
+        async deleteTargetGroup(@Args("id", { type: () => ID }) id: string): Promise<boolean> {
+            const targetGroup = await this.repository.findOneOrFail(id);
+            await this.entityManager.remove(targetGroup);
+            await this.entityManager.flush();
+            return true;
+        }
+    }
+
+    return TargetGroupResolver;
+}

--- a/packages/api/src/target-group/target-groups.service.ts
+++ b/packages/api/src/target-group/target-groups.service.ts
@@ -1,0 +1,23 @@
+import { filtersToMikroOrmQuery, searchToMikroOrmQuery } from "@comet/cms-api";
+import { ObjectQuery } from "@mikro-orm/core";
+import { Injectable } from "@nestjs/common";
+
+import { TargetGroupFilter } from "./dto/target-group.filter";
+import { TargetGroupInterface } from "./entity/target-group-entity.factory";
+
+@Injectable()
+export class TargetGroupsService {
+    getFindCondition(options: { search?: string; filter?: TargetGroupFilter }): ObjectQuery<TargetGroupInterface> {
+        const andFilters = [];
+
+        if (options.search) {
+            andFilters.push(searchToMikroOrmQuery(options.search, ["title"]));
+        }
+
+        if (options.filter) {
+            andFilters.push(filtersToMikroOrmQuery(options.filter));
+        }
+
+        return andFilters.length > 0 ? { $and: andFilters } : {};
+    }
+}

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -2,4 +2,7 @@
 export type BrevoContactAttributesInterface = Record<string, any>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type BrevoContactFilterAttributesInterface = Record<string, any>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type EmailCampaignScopeInterface = Record<string, any>;


### PR DESCRIPTION
depends on #8 

Adds basic target group functionality for saving in database. I will add the logic for the brevo contact list / target group in the follow up PR. 

This is part of COM-268