### PR TITLE
add contact list brevo api functionality to target groups

### DIFF
--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -67,6 +67,8 @@ type DamFileLicense {
 enum LicenseType {
   ROYALTY_FREE
   RIGHTS_MANAGED
+  SUBSCRIPTION
+  MICRO
 }
 
 """
@@ -264,8 +266,6 @@ type DamFile {
   license: DamFileLicense
   createdAt: DateTime!
   updatedAt: DateTime!
-  importSourceId: String
-  importSourceType: String
   fileUrl: String!
   duplicates: [DamFile!]!
   damPath: String!
@@ -358,6 +358,24 @@ type PaginatedBrevoContacts {
   totalCount: Int!
 }
 
+type TargetGroup implements DocumentInterface {
+  id: ID!
+  updatedAt: DateTime!
+  createdAt: DateTime!
+  title: String!
+  isMainList: Boolean!
+  brevoId: Int!
+  totalSubscribers: Int!
+  totalContactsBlocked: Int!
+  scope: EmailCampaignContentScope!
+  filters: BrevoContactFilterAttributes
+}
+
+type PaginatedTargetGroups {
+  nodes: [TargetGroup!]!
+  totalCount: Int!
+}
+
 type EmailCampaign implements DocumentInterface {
   id: ID!
   updatedAt: DateTime!
@@ -382,24 +400,6 @@ scalar EmailCampaignContentBlockData @specifiedBy(url: "http://www.ecma-internat
 
 type PaginatedEmailCampaigns {
   nodes: [EmailCampaign!]!
-  totalCount: Int!
-}
-
-type TargetGroup implements DocumentInterface {
-  id: ID!
-  updatedAt: DateTime!
-  createdAt: DateTime!
-  title: String!
-  isMainList: Boolean!
-  brevoId: Int!
-  totalSubscribers: Int!
-  totalContactsBlocked: Int!
-  scope: EmailCampaignContentScope!
-  filters: BrevoContactFilterAttributes
-}
-
-type PaginatedTargetGroups {
-  nodes: [TargetGroup!]!
   totalCount: Int!
 }
 
@@ -455,7 +455,7 @@ type Query {
   products(offset: Int! = 0, limit: Int! = 25, search: String, filter: ProductFilter, sort: [ProductSort!]): PaginatedProducts!
   mainMenu(scope: PageTreeNodeScopeInput!): [PageTreeNode!]!
   brevoContact(id: Int!): BrevoContact!
-  brevoContacts(offset: Int! = 0, limit: Int! = 25, email: String): PaginatedBrevoContacts!
+  brevoContacts(targetGroupId: ID, email: String, scope: EmailCampaignContentScopeInput!, offset: Int! = 0, limit: Int! = 25): PaginatedBrevoContacts!
   emailCampaign(id: ID!): EmailCampaign!
   emailCampaigns(scope: EmailCampaignContentScopeInput!, search: String, filter: EmailCampaignFilter, sort: [EmailCampaignSort!], offset: Int! = 0, limit: Int! = 25): PaginatedEmailCampaigns!
   targetGroup(id: ID!): TargetGroup!
@@ -796,6 +796,7 @@ enum SubscribeResponse {
 input SubscribeInput {
   email: String!
   redirectionUrl: String!
+  scope: EmailCampaignContentScopeInput!
   attributes: BrevoContactAttributesInput!
 }
 

--- a/demo/api/src/brevo-contact/dto/brevo-contact-attributes.ts
+++ b/demo/api/src/brevo-contact/dto/brevo-contact-attributes.ts
@@ -28,6 +28,10 @@ export class BrevoContactAttributes {
 @ObjectType()
 @InputType("BrevoContactFilterAttributesInput")
 export class BrevoContactFilterAttributes {
+    // index signature to match Record<string, string> in BrevoContactFilterAttributesInterface
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    [key: string]: Array<any> | undefined;
+
     @Field(() => [BrevoContactSalutation], { nullable: true })
     @IsEnum(BrevoContactSalutation, { each: true })
     @Enum({ items: () => BrevoContactSalutation, array: true })

--- a/demo/api/src/brevo-contact/dto/brevo-contact-attributes.ts
+++ b/demo/api/src/brevo-contact/dto/brevo-contact-attributes.ts
@@ -28,7 +28,7 @@ export class BrevoContactAttributes {
 @ObjectType()
 @InputType("BrevoContactFilterAttributesInput")
 export class BrevoContactFilterAttributes {
-    // index signature to match Record<string, string> in BrevoContactFilterAttributesInterface
+    // index signature to match Array<any> | undefined in BrevoContactFilterAttributesInterface
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [key: string]: Array<any> | undefined;
 

--- a/packages/api/src/brevo-api/dto/brevo-api-contact-list.ts
+++ b/packages/api/src/brevo-api/dto/brevo-api-contact-list.ts
@@ -1,0 +1,28 @@
+import { Field, ID, Int, ObjectType } from "@nestjs/graphql";
+
+@ObjectType()
+export class BrevoApiContactList {
+    @Field(() => ID)
+    id: number;
+
+    @Field(() => String)
+    createdAt: string;
+
+    @Field(() => String)
+    name: string;
+
+    @Field(() => Int)
+    totalBlacklisted: number;
+
+    @Field(() => Int)
+    totalSubscribers: number;
+
+    @Field(() => Int)
+    uniqueSubscribers: number;
+
+    @Field(() => Int)
+    folderId: number;
+
+    @Field(() => Boolean, { nullable: true })
+    dynamicList?: boolean;
+}

--- a/packages/api/src/brevo-contact/brevo-contact.module.ts
+++ b/packages/api/src/brevo-contact/brevo-contact.module.ts
@@ -2,7 +2,8 @@ import { DynamicModule, Module, Type } from "@nestjs/common";
 
 import { BrevoApiModule } from "../brevo-api/brevo-api.module";
 import { ConfigModule } from "../config/config.module";
-import { BrevoContactAttributesInterface } from "../types";
+import { TargetGroupModule } from "../target-group/target-group.module";
+import { BrevoContactAttributesInterface, BrevoContactFilterAttributesInterface, EmailCampaignScopeInterface } from "../types";
 import { createBrevoContactResolver } from "./brevo-contact.resolver";
 import { BrevoContactsService } from "./brevo-contacts.service";
 import { BrevoContactFactory } from "./dto/brevo-contact.factory";
@@ -12,18 +13,20 @@ import { IsValidRedirectURLConstraint } from "./validator/redirect-url.validator
 
 interface BrevoContactModuleConfig {
     BrevoContactAttributes?: Type<BrevoContactAttributesInterface>;
+    Scope: Type<EmailCampaignScopeInterface>;
+    BrevoFilterAttributes?: Type<BrevoContactFilterAttributesInterface>;
 }
 
 @Module({})
 export class BrevoContactModule {
-    static register({ BrevoContactAttributes }: BrevoContactModuleConfig): DynamicModule {
+    static register({ BrevoContactAttributes, Scope, BrevoFilterAttributes }: BrevoContactModuleConfig): DynamicModule {
         const BrevoContact = BrevoContactFactory.create({ BrevoContactAttributes });
-        const BrevoContactSubscribeInput = SubscribeInputFactory.create({ BrevoContactAttributes });
-        const BrevoContactResolver = createBrevoContactResolver({ BrevoContact, BrevoContactSubscribeInput });
+        const BrevoContactSubscribeInput = SubscribeInputFactory.create({ BrevoContactAttributes, Scope });
+        const BrevoContactResolver = createBrevoContactResolver({ BrevoContact, BrevoContactSubscribeInput, Scope });
 
         return {
             module: BrevoContactModule,
-            imports: [BrevoApiModule, ConfigModule],
+            imports: [BrevoApiModule, ConfigModule, TargetGroupModule.register({ Scope, BrevoFilterAttributes })],
             providers: [BrevoContactsService, BrevoContactResolver, EcgRtrListService, IsValidRedirectURLConstraint],
         };
     }

--- a/packages/api/src/brevo-contact/brevo-contacts.service.ts
+++ b/packages/api/src/brevo-contact/brevo-contacts.service.ts
@@ -1,17 +1,37 @@
 import { Injectable } from "@nestjs/common";
 
-import { BrevoApiContactsService, CreateDoubleOptInContactData } from "../brevo-api/brevo-api-contact.service";
+import { BrevoApiContactsService } from "../brevo-api/brevo-api-contact.service";
+import { TargetGroupsService } from "../target-group/target-groups.service";
+import { SubscribeInputInterface } from "./dto/subscribe-input.factory";
 import { SubscribeResponse } from "./dto/subscribe-response.enum";
 
 @Injectable()
 export class BrevoContactsService {
-    constructor(private readonly brevoContactsApiService: BrevoApiContactsService) {}
+    constructor(private readonly brevoContactsApiService: BrevoApiContactsService, private readonly targetGroupService: TargetGroupsService) {}
 
-    public async createDoubleOptInContact(data: CreateDoubleOptInContactData, templateId: number): Promise<SubscribeResponse> {
-        // TODO: add correct lists when brevo contact list is implemented
-        const contactListId = 2;
+    public async createDoubleOptInContact(data: SubscribeInputInterface, templateId: number): Promise<SubscribeResponse> {
+        const mainTargetGroupForScope = await this.targetGroupService.createIfNotExistMainTargetGroupForScope(data.scope);
 
-        const created = await this.brevoContactsApiService.createDoubleOptInContact(data, [contactListId], templateId);
+        let offset = 0;
+        let totalCount = 0;
+        const targetGroupIds: number[] = [];
+        const limit = 50;
+
+        do {
+            const [targetGroups, totalContactLists] = await this.targetGroupService.findNonMainTargetGroups(data, offset, limit);
+            totalCount = totalContactLists;
+            offset += targetGroups.length;
+
+            for (const targetGroup of targetGroups) {
+                const contactIsInTargetGroup = this.targetGroupService.checkIfContactIsInTargetGroup(data, targetGroup.filters);
+
+                if (contactIsInTargetGroup) {
+                    targetGroupIds.push(targetGroup.brevoId);
+                }
+            }
+        } while (offset < totalCount);
+
+        const created = await this.brevoContactsApiService.createDoubleOptInBrevoContact(data, [mainTargetGroupForScope.brevoId], templateId);
         if (created) {
             return SubscribeResponse.SUCCESSFUL;
         }

--- a/packages/api/src/brevo-contact/dto/brevo-contacts.args.ts
+++ b/packages/api/src/brevo-contact/dto/brevo-contacts.args.ts
@@ -1,12 +1,36 @@
 import { OffsetBasedPaginationArgs } from "@comet/cms-api";
-import { ArgsType, Field } from "@nestjs/graphql";
-import { IsOptional } from "class-validator";
+import { Type } from "@nestjs/common";
+import { ArgsType, Field, ID } from "@nestjs/graphql";
+import { Type as TransformerType } from "class-transformer";
+import { IsOptional, IsString, ValidateNested } from "class-validator";
 
-@ArgsType()
-export class BrevoContactsArgs extends OffsetBasedPaginationArgs {
-    // TODO: add scope
+import { EmailCampaignScopeInterface } from "../../types";
 
-    @Field(() => String, { nullable: true })
-    @IsOptional()
+export interface BrevoContactsArgsInterface extends OffsetBasedPaginationArgs {
+    scope: EmailCampaignScopeInterface;
+    targetGroupId?: string;
     email?: string;
+}
+
+export class BrevoContactsArgsFactory {
+    static create({ Scope }: { Scope: Type<EmailCampaignScopeInterface> }) {
+        @ArgsType()
+        class BrevoContactsArgs extends OffsetBasedPaginationArgs {
+            @Field(() => ID, { nullable: true })
+            @IsString()
+            @IsOptional()
+            targetGroupId?: string;
+
+            @Field(() => String, { nullable: true })
+            @IsOptional()
+            email?: string;
+
+            @Field(() => Scope)
+            @TransformerType(() => Scope)
+            @ValidateNested()
+            scope: EmailCampaignScopeInterface;
+        }
+
+        return BrevoContactsArgs;
+    }
 }

--- a/packages/api/src/brevo-contact/dto/brevo-contacts.args.ts
+++ b/packages/api/src/brevo-contact/dto/brevo-contacts.args.ts
@@ -2,7 +2,7 @@ import { OffsetBasedPaginationArgs } from "@comet/cms-api";
 import { Type } from "@nestjs/common";
 import { ArgsType, Field, ID } from "@nestjs/graphql";
 import { Type as TransformerType } from "class-transformer";
-import { IsOptional, IsString, ValidateNested } from "class-validator";
+import { IsEmail, IsOptional, IsString, ValidateNested } from "class-validator";
 
 import { EmailCampaignScopeInterface } from "../../types";
 
@@ -23,6 +23,7 @@ export class BrevoContactsArgsFactory {
 
             @Field(() => String, { nullable: true })
             @IsOptional()
+            @IsEmail()
             email?: string;
 
             @Field(() => Scope)

--- a/packages/api/src/brevo-contact/dto/subscribe-input.factory.ts
+++ b/packages/api/src/brevo-contact/dto/subscribe-input.factory.ts
@@ -1,18 +1,26 @@
 import { Type } from "@nestjs/common";
 import { Field, InputType } from "@nestjs/graphql";
-import { IsEmail, IsUrl, Validate } from "class-validator";
+import { Type as TransformerType } from "class-transformer";
+import { IsEmail, IsUrl, Validate, ValidateNested } from "class-validator";
 
-import { BrevoContactAttributesInterface } from "../../types";
+import { BrevoContactAttributesInterface, EmailCampaignScopeInterface } from "../../types";
 import { IsValidRedirectURLConstraint } from "../validator/redirect-url.validator";
 
 export interface SubscribeInputInterface {
     email: string;
     redirectionUrl: string;
     attributes?: BrevoContactAttributesInterface;
+    scope: EmailCampaignScopeInterface;
 }
 
 export class SubscribeInputFactory {
-    static create({ BrevoContactAttributes }: { BrevoContactAttributes?: Type<BrevoContactAttributesInterface> }): Type<SubscribeInputInterface> {
+    static create({
+        BrevoContactAttributes,
+        Scope,
+    }: {
+        BrevoContactAttributes?: Type<BrevoContactAttributesInterface>;
+        Scope: Type<EmailCampaignScopeInterface>;
+    }): Type<SubscribeInputInterface> {
         @InputType({ isAbstract: true })
         class SubscribeInputBase implements SubscribeInputInterface {
             @Field()
@@ -23,6 +31,11 @@ export class SubscribeInputFactory {
             @IsUrl({ require_tld: process.env.NODE_ENV === "production" })
             @Validate(IsValidRedirectURLConstraint)
             redirectionUrl: string;
+
+            @Field(() => Scope)
+            @TransformerType(() => Scope)
+            @ValidateNested()
+            scope: EmailCampaignScopeInterface;
         }
 
         if (BrevoContactAttributes) {

--- a/packages/api/src/brevo-module.ts
+++ b/packages/api/src/brevo-module.ts
@@ -15,9 +15,13 @@ export class BrevoModule {
             module: BrevoModule,
             imports: [
                 BrevoApiModule,
-                BrevoContactModule.register({ BrevoContactAttributes: config.brevo.BrevoContactAttributes }),
+                BrevoContactModule.register({
+                    BrevoContactAttributes: config.brevo.BrevoContactAttributes,
+                    BrevoFilterAttributes: config.brevo.BrevoContactFilterAttributes,
+                    Scope: config.Scope,
+                }),
                 EmailCampaignModule.register(config),
-                TargetGroupModule.register({ Scope: config.Scope, BrevoFilterAttributes: config.brevo.BrevoContactFilterAttributes }),
+                TargetGroupModule,
                 ConfigModule.forRoot(config),
             ],
             exports: [],

--- a/packages/api/src/target-group/entity/target-group-entity.factory.ts
+++ b/packages/api/src/target-group/entity/target-group-entity.factory.ts
@@ -17,7 +17,7 @@ export interface TargetGroupInterface {
     totalSubscribers: number;
     totalContactsBlocked: number;
     scope: EmailCampaignScopeInterface;
-    filters?: BrevoContactFilterAttributesInterface;
+    filters?: Type<BrevoContactFilterAttributesInterface>;
 }
 
 export class TargetGroupEntityFactory {

--- a/packages/api/src/target-group/target-group.module.ts
+++ b/packages/api/src/target-group/target-group.module.ts
@@ -1,7 +1,7 @@
 import { MikroOrmModule } from "@mikro-orm/nestjs";
 import { DynamicModule, Module, Type } from "@nestjs/common";
 
-import { BrevoModule } from "../brevo-module";
+import { BrevoApiModule } from "../brevo-api/brevo-api.module";
 import { ConfigModule } from "../config/config.module";
 import { BrevoContactFilterAttributesInterface, EmailCampaignScopeInterface } from "../types";
 import { TargetGroupInputFactory } from "./dto/target-group-input.factory";
@@ -23,8 +23,9 @@ export class TargetGroupModule {
 
         return {
             module: TargetGroupModule,
-            imports: [ConfigModule, BrevoModule, MikroOrmModule.forFeature([TargetGroup])],
+            imports: [ConfigModule, BrevoApiModule, MikroOrmModule.forFeature([TargetGroup])],
             providers: [TargetGroupResolver, TargetGroupsService],
+            exports: [TargetGroupsService],
         };
     }
 }

--- a/packages/api/src/target-group/target-groups.service.ts
+++ b/packages/api/src/target-group/target-groups.service.ts
@@ -1,12 +1,24 @@
 import { filtersToMikroOrmQuery, searchToMikroOrmQuery } from "@comet/cms-api";
-import { ObjectQuery } from "@mikro-orm/core";
+import { EntityManager, EntityRepository, FilterQuery, ObjectQuery } from "@mikro-orm/core";
+import { InjectRepository } from "@mikro-orm/nestjs";
 import { Injectable } from "@nestjs/common";
 
+import { BrevoApiContactsService } from "../brevo-api/brevo-api-contact.service";
+import { BrevoContactInterface } from "../brevo-contact/dto/brevo-contact.factory";
+import { SubscribeInputInterface } from "../brevo-contact/dto/subscribe-input.factory";
+import { BrevoContactAttributesInterface, BrevoContactFilterAttributesInterface, EmailCampaignScopeInterface } from "../types";
 import { TargetGroupFilter } from "./dto/target-group.filter";
+import { TargetGroupInputInterface } from "./dto/target-group-input.factory";
 import { TargetGroupInterface } from "./entity/target-group-entity.factory";
 
 @Injectable()
 export class TargetGroupsService {
+    constructor(
+        @InjectRepository("TargetGroup") private readonly repository: EntityRepository<TargetGroupInterface>,
+        private readonly brevoApiContactsService: BrevoApiContactsService,
+        private readonly entityManager: EntityManager,
+    ) {}
+
     getFindCondition(options: { search?: string; filter?: TargetGroupFilter }): ObjectQuery<TargetGroupInterface> {
         const andFilters = [];
 
@@ -19,5 +31,102 @@ export class TargetGroupsService {
         }
 
         return andFilters.length > 0 ? { $and: andFilters } : {};
+    }
+
+    public checkIfContactIsInTargetGroup(
+        contactAttributes?: BrevoContactAttributesInterface,
+        filters?: BrevoContactFilterAttributesInterface,
+    ): boolean {
+        if (!contactAttributes) return false;
+
+        if (filters) {
+            for (const [key, value] of Object.entries(filters)) {
+                if (!value) continue;
+                if (value.includes(contactAttributes[key])) {
+                    continue;
+                }
+
+                return false;
+            }
+            return true;
+        }
+
+        return true;
+    }
+
+    public async assignContactsToContactList(input: TargetGroupInputInterface, brevoId: number, scope: EmailCampaignScopeInterface): Promise<true> {
+        const mainScopeTargetGroupList = await this.repository.findOneOrFail({ scope, isMainList: true });
+
+        let offset = 0;
+        let totalCount = 0;
+        do {
+            const [contacts, totalContacts] = await this.brevoApiContactsService.findContactsByListId(mainScopeTargetGroupList.brevoId, 50, offset);
+            totalCount = totalContacts;
+            offset += contacts.length;
+
+            const contactsInContactList: BrevoContactInterface[] = [];
+            const contactsNotInContactList: BrevoContactInterface[] = [];
+
+            for (const contact of contacts) {
+                const contactIsInTargetGroup = this.checkIfContactIsInTargetGroup(contact.attributes, input.filters);
+
+                if (contactIsInTargetGroup) {
+                    contactsInContactList.push(contact);
+                } else {
+                    contactsNotInContactList.push(contact);
+                }
+            }
+
+            if (contactsInContactList.length > 0) {
+                await this.brevoApiContactsService.updateMultipleContacts(
+                    contactsInContactList.map((contact) => ({ id: contact.id, listIds: [brevoId] })),
+                );
+            }
+            if (contactsNotInContactList.length > 0) {
+                await this.brevoApiContactsService.updateMultipleContacts(
+                    contactsNotInContactList.map((contact) => ({ id: contact.id, unlinkListIds: [brevoId] })),
+                );
+            }
+        } while (offset < totalCount);
+
+        return true;
+    }
+
+    async findNonMainTargetGroups(data: SubscribeInputInterface, offset: number, limit: number): Promise<[TargetGroupInterface[], number]> {
+        const [targetGroups, totalContactLists] = await this.repository.findAndCount(
+            {
+                scope: data.scope,
+                isMainList: false,
+            },
+            { limit, offset },
+        );
+
+        return [targetGroups, totalContactLists];
+    }
+
+    async findOneTargetGroup(where: FilterQuery<TargetGroupInterface>): Promise<TargetGroupInterface | null> {
+        const targetGroup = await this.repository.findOne(where);
+        return targetGroup;
+    }
+
+    public async createIfNotExistMainTargetGroupForScope(scope: EmailCampaignScopeInterface): Promise<TargetGroupInterface> {
+        const mainList = await this.repository.findOne({ scope, isMainList: true });
+
+        if (mainList) {
+            return mainList;
+        }
+
+        const title = "Main list for current scope";
+        const brevoId = await this.brevoApiContactsService.createBrevoContactList({ title });
+
+        if (brevoId) {
+            const mainTargetGroupForScope = this.repository.create({ title, brevoId, scope, isMainList: true });
+
+            await this.entityManager.flush();
+
+            return mainTargetGroupForScope;
+        }
+
+        throw new Error("Brevo Error: Could not create contact list");
     }
 }

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -2,7 +2,7 @@
 export type BrevoContactAttributesInterface = Record<string, any>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type BrevoContactFilterAttributesInterface = Record<string, any>;
+export type BrevoContactFilterAttributesInterface = Record<string, Array<any> | undefined>;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type EmailCampaignScopeInterface = Record<string, any>;


### PR DESCRIPTION
Adds brevo api functionality to the target groups. 

In the follow up MR I will add the target groups to the brevo campaign, then the target groups will be finished

This is part of COM-268