### PR TITLE
fix missing copy of schema.gql from api to admin

### DIFF
--- a/copy-schema-files.js
+++ b/copy-schema-files.js
@@ -2,6 +2,8 @@ const fs = require("fs");
 
 (async () => {
     await Promise.all([
+        fs.promises.copyFile("packages/api/schema.gql", "packages/admin/schema.gql"),
+
         fs.promises.copyFile("demo/api/block-meta.json", "demo/admin/block-meta.json"),
         fs.promises.copyFile("demo/api/block-meta.json", "demo/site/block-meta.json"),
         fs.promises.copyFile("demo/api/schema.gql", "demo/admin/schema.gql"),


### PR DESCRIPTION
This should fix the failing release pipeline https://github.com/vivid-planet/comet-brevo-module/actions/runs/7650959672/job/20847908849

Part of COM-272