### PR TITLE
COM-271: Add dynamic fields to target group form

### DIFF
--- a/demo/admin/src/Routes.tsx
+++ b/demo/admin/src/Routes.tsx
@@ -9,6 +9,7 @@ import { useIntl } from "react-intl";
 import { RouteComponentProps } from "react-router";
 import { Redirect, Route, Switch } from "react-router-dom";
 
+import { additionalFormConfig } from "./common/brevoModuleConfig/targetGroupFormConfig";
 import { ContentScopeIndicatorContent, ContentScopeIndicatorDomain, ContentScopeIndicatorLanguage } from "./common/ContentScopeIndicatorStyles";
 import { ContentScopeProvider } from "./common/ContentScopeProvider";
 import { MasterHeader } from "./common/MasterHeader";
@@ -19,16 +20,22 @@ import { Page } from "./documents/pages/Page";
 import { ProductsPage } from "./products/ProductsPage";
 
 const RedirectsPage = createRedirectsPage();
-const TargetGroupsPage = createTargetGroupsPage({ scopeParts: ["domain", "language"] });
 
 export const Routes: React.FC = () => {
     const intl = useIntl();
     const brevoContactConfig = getBrevoContactConfig(intl);
-
     const BrevoContactsPage = createBrevoContactsPage({
         scopeParts: ["domain", "language"],
         additionalAttributesFragment: brevoContactConfig.additionalAttributesFragment,
         additionalGridFields: brevoContactConfig.additionalGridFields,
+    });
+
+    const TargetGroupsPage = createTargetGroupsPage({
+        scopeParts: ["domain", "language"],
+        additionalFormFields: additionalFormConfig.additionalFormFields,
+        nodeFragment: additionalFormConfig.nodeFragment,
+        dataToInitialValues: additionalFormConfig.dataToInitialValues,
+        valuesToOutput: additionalFormConfig.valuesToOutput,
     });
 
     return (

--- a/demo/admin/src/Routes.tsx
+++ b/demo/admin/src/Routes.tsx
@@ -35,7 +35,6 @@ export const Routes: React.FC = () => {
         additionalFormFields: additionalFormConfig.additionalFormFields,
         nodeFragment: additionalFormConfig.nodeFragment,
         dataToInitialValues: additionalFormConfig.dataToInitialValues,
-        valuesToOutput: additionalFormConfig.valuesToOutput,
     });
 
     return (

--- a/demo/admin/src/Routes.tsx
+++ b/demo/admin/src/Routes.tsx
@@ -34,7 +34,7 @@ export const Routes: React.FC = () => {
         scopeParts: ["domain", "language"],
         additionalFormFields: additionalFormConfig.additionalFormFields,
         nodeFragment: additionalFormConfig.nodeFragment,
-        dataToInitialValues: additionalFormConfig.dataToInitialValues,
+        input2State: additionalFormConfig.input2State,
     });
 
     return (

--- a/demo/admin/src/common/brevoModuleConfig/targetGroupFormConfig.tsx
+++ b/demo/admin/src/common/brevoModuleConfig/targetGroupFormConfig.tsx
@@ -27,26 +27,17 @@ export const additionalPageTreeNodeFieldsFragment = {
 };
 
 export const additionalFormConfig = {
-    valuesToOutput: (values: { salutation: string[] }) => {
-        const valuesWithoutSalutation: { salutation?: string[] } = { ...values };
-        delete valuesWithoutSalutation.salutation;
-
-        return {
-            ...valuesWithoutSalutation,
-            filters: {
-                SALUTATION: values.salutation,
-            },
-        };
-    },
     dataToInitialValues: (values?: { filters: { SALUTATION: string[] } }) => {
         return {
-            salutation: values?.filters?.SALUTATION ?? [],
+            filters: {
+                SALUTATION: values?.filters?.SALUTATION ?? [],
+            },
         };
     },
     nodeFragment: additionalPageTreeNodeFieldsFragment,
     additionalFormFields: (
         <>
-            <Field label={<FormattedMessage id="targetGroup.fields.salutation" defaultMessage="Salutation" />} name="salutation" fullWidth>
+            <Field label={<FormattedMessage id="targetGroup.fields.salutation" defaultMessage="Salutation" />} name="filters.SALUTATION" fullWidth>
                 {(props) => (
                     <FinalFormSelect {...props} fullWidth multiple clearable>
                         {salutationOptions.map((option) => (

--- a/demo/admin/src/common/brevoModuleConfig/targetGroupFormConfig.tsx
+++ b/demo/admin/src/common/brevoModuleConfig/targetGroupFormConfig.tsx
@@ -28,7 +28,7 @@ export const additionalPageTreeNodeFieldsFragment = {
 };
 
 export const additionalFormConfig = {
-    dataToInitialValues: (values?: { filters: { SALUTATION: Array<GQLBrevoContactSalutation> } }) => {
+    input2State: (values?: { filters: { SALUTATION: Array<GQLBrevoContactSalutation> } }) => {
         return {
             filters: {
                 SALUTATION: values?.filters?.SALUTATION ?? [],

--- a/demo/admin/src/common/brevoModuleConfig/targetGroupFormConfig.tsx
+++ b/demo/admin/src/common/brevoModuleConfig/targetGroupFormConfig.tsx
@@ -1,10 +1,11 @@
 import { gql } from "@apollo/client";
 import { Field, FinalFormSelect } from "@comet/admin";
 import { MenuItem } from "@mui/material";
+import { GQLBrevoContactSalutation } from "@src/graphql.generated";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
-const salutationOptions = [
+const salutationOptions: Array<{ label: React.ReactNode; value: GQLBrevoContactSalutation }> = [
     {
         label: <FormattedMessage id="targetGroup.filters.salutation.male." defaultMessage="Male" />,
         value: "MALE",
@@ -27,7 +28,7 @@ export const additionalPageTreeNodeFieldsFragment = {
 };
 
 export const additionalFormConfig = {
-    dataToInitialValues: (values?: { filters: { SALUTATION: string[] } }) => {
+    dataToInitialValues: (values?: { filters: { SALUTATION: Array<GQLBrevoContactSalutation> } }) => {
         return {
             filters: {
                 SALUTATION: values?.filters?.SALUTATION ?? [],

--- a/demo/admin/src/common/brevoModuleConfig/targetGroupFormConfig.tsx
+++ b/demo/admin/src/common/brevoModuleConfig/targetGroupFormConfig.tsx
@@ -1,0 +1,62 @@
+import { gql } from "@apollo/client";
+import { Field, FinalFormSelect } from "@comet/admin";
+import { MenuItem } from "@mui/material";
+import * as React from "react";
+import { FormattedMessage } from "react-intl";
+
+const salutationOptions = [
+    {
+        label: <FormattedMessage id="targetGroup.filters.salutation.male." defaultMessage="Male" />,
+        value: "MALE",
+    },
+    {
+        label: <FormattedMessage id="targetGroup.filters.salutation.female." defaultMessage="Female" />,
+        value: "FEMALE",
+    },
+];
+
+export const additionalPageTreeNodeFieldsFragment = {
+    fragment: gql`
+        fragment TargetGroupFilters on TargetGroup {
+            filters {
+                SALUTATION
+            }
+        }
+    `,
+    name: "TargetGroupFilters",
+};
+
+export const additionalFormConfig = {
+    valuesToOutput: (values: { salutation: string[] }) => {
+        const valuesWithoutSalutation: { salutation?: string[] } = { ...values };
+        delete valuesWithoutSalutation.salutation;
+
+        return {
+            ...valuesWithoutSalutation,
+            filters: {
+                SALUTATION: values.salutation,
+            },
+        };
+    },
+    dataToInitialValues: (values?: { filters: { SALUTATION: string[] } }) => {
+        return {
+            salutation: values?.filters?.SALUTATION ?? [],
+        };
+    },
+    nodeFragment: additionalPageTreeNodeFieldsFragment,
+    additionalFormFields: (
+        <>
+            <Field label={<FormattedMessage id="targetGroup.fields.salutation" defaultMessage="Salutation" />} name="salutation" fullWidth>
+                {(props) => (
+                    <FinalFormSelect {...props} fullWidth multiple clearable>
+                        {salutationOptions.map((option) => (
+                            <MenuItem value={option.value} key={option.value}>
+                                {option.label}
+                            </MenuItem>
+                        ))}
+                    </FinalFormSelect>
+                )}
+            </Field>
+        </>
+    ),
+};

--- a/packages/admin/.eslintrc.json
+++ b/packages/admin/.eslintrc.json
@@ -1,4 +1,4 @@
 {
     "extends": "@comet/eslint-config/react",
-    "ignorePatterns": ["src/*.generated.ts", "lib/**"]
+    "ignorePatterns": ["**/*.generated.ts", "lib/**"]
 }

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -64,7 +64,6 @@
         "rimraf": "^3.0.2",
         "typescript": "^4.0.0"
     },
-
     "peerDependencies": {
         "@apollo/client": "^3.2.5",
         "@comet/admin": "^5.3.0",

--- a/packages/admin/src/targetGroups/TargetGroupForm.gql.ts
+++ b/packages/admin/src/targetGroups/TargetGroupForm.gql.ts
@@ -1,12 +1,6 @@
-import { gql } from "@apollo/client";
+import { DocumentNode, gql } from "@apollo/client";
 
-export const targetGroupFormFragment = gql`
-    fragment TargetGroupForm on TargetGroup {
-        title
-    }
-`;
-
-export const targetGroupFormQuery = gql`
+export const targetGroupFormQuery = (targetGroupFormFragment: DocumentNode) => gql`
     query TargetGroupForm($id: ID!) {
         targetGroup(id: $id) {
             id
@@ -25,7 +19,7 @@ export const targetGroupFormCheckForChangesQuery = gql`
     }
 `;
 
-export const createTargetGroupMutation = gql`
+export const createTargetGroupMutation = (targetGroupFormFragment: DocumentNode) => gql`
     mutation CreateTargetGroup($scope: EmailCampaignContentScopeInput!, $input: TargetGroupInput!) {
         createTargetGroup(scope: $scope, input: $input) {
             id
@@ -36,7 +30,7 @@ export const createTargetGroupMutation = gql`
     ${targetGroupFormFragment}
 `;
 
-export const updateTargetGroupMutation = gql`
+export const updateTargetGroupMutation = (targetGroupFormFragment: DocumentNode) => gql`
     mutation UpdateTargetGroup($id: ID!, $input: TargetGroupUpdateInput!, $lastUpdatedAt: DateTime) {
         updateTargetGroup(id: $id, input: $input, lastUpdatedAt: $lastUpdatedAt) {
             id

--- a/packages/admin/src/targetGroups/TargetGroupForm.tsx
+++ b/packages/admin/src/targetGroups/TargetGroupForm.tsx
@@ -44,10 +44,10 @@ interface FormProps {
     scope: ContentScopeInterface;
     additionalFormFields?: React.ReactNode;
     nodeFragment?: { name: string; fragment: DocumentNode };
-    dataToInitialValues?: (values?: EditTargetGroupFinalFormValues) => EditTargetGroupFinalFormValues;
+    input2State?: (values?: EditTargetGroupFinalFormValues) => EditTargetGroupFinalFormValues;
 }
 
-export function TargetGroupForm({ id, scope, additionalFormFields, dataToInitialValues, nodeFragment }: FormProps): React.ReactElement {
+export function TargetGroupForm({ id, scope, additionalFormFields, input2State, nodeFragment }: FormProps): React.ReactElement {
     const stackApi = useStackApi();
     const client = useApolloClient();
     const mode = id ? "edit" : "add";
@@ -70,12 +70,12 @@ export function TargetGroupForm({ id, scope, additionalFormFields, dataToInitial
     const initialValues = React.useMemo<Partial<EditTargetGroupFinalFormValues>>(() => {
         let additionalInitialValues = {};
 
-        if (dataToInitialValues) {
-            additionalInitialValues = dataToInitialValues(data?.targetGroup);
+        if (input2State) {
+            additionalInitialValues = input2State(data?.targetGroup);
         }
 
         return data?.targetGroup ? { title: data.targetGroup.title, ...additionalInitialValues } : { ...additionalInitialValues };
-    }, [data?.targetGroup, dataToInitialValues]);
+    }, [data?.targetGroup, input2State]);
 
     const saveConflict = useFormSaveConflict({
         checkConflict: async () => {

--- a/packages/admin/src/targetGroups/TargetGroupForm.tsx
+++ b/packages/admin/src/targetGroups/TargetGroupForm.tsx
@@ -28,14 +28,16 @@ import { createTargetGroupMutation, targetGroupFormQuery, updateTargetGroupMutat
 import {
     GQLCreateTargetGroupMutation,
     GQLCreateTargetGroupMutationVariables,
-    GQLTargetGroupFormFragment,
     GQLTargetGroupFormQuery,
     GQLTargetGroupFormQueryVariables,
     GQLUpdateTargetGroupMutation,
     GQLUpdateTargetGroupMutationVariables,
 } from "./TargetGroupForm.gql.generated";
 
-type FormValues = GQLTargetGroupFormFragment;
+type FormValues = {
+    title: string;
+    [key: string]: unknown;
+};
 
 export interface EditTargetGroupFinalFormValues {
     [key: string]: unknown;

--- a/packages/admin/src/targetGroups/TargetGroupForm.tsx
+++ b/packages/admin/src/targetGroups/TargetGroupForm.tsx
@@ -74,7 +74,7 @@ export function TargetGroupForm({ id, scope, additionalFormFields, input2State, 
             additionalInitialValues = input2State(data?.targetGroup);
         }
 
-        return data?.targetGroup ? { title: data.targetGroup.title, ...additionalInitialValues } : { ...additionalInitialValues };
+        return data?.targetGroup ? { title: data.targetGroup.title, ...additionalInitialValues } : additionalInitialValues;
     }, [data?.targetGroup, input2State]);
 
     const saveConflict = useFormSaveConflict({

--- a/packages/admin/src/targetGroups/TargetGroupForm.tsx
+++ b/packages/admin/src/targetGroups/TargetGroupForm.tsx
@@ -47,17 +47,9 @@ interface FormProps {
     additionalFormFields?: React.ReactNode;
     nodeFragment?: { name: string; fragment: DocumentNode };
     dataToInitialValues?: (values?: EditTargetGroupFinalFormValues) => EditTargetGroupFinalFormValues;
-    valuesToOutput?: (values: EditTargetGroupFinalFormValues) => EditTargetGroupFinalFormValues;
 }
 
-export function TargetGroupForm({
-    id,
-    scope,
-    additionalFormFields,
-    dataToInitialValues,
-    nodeFragment,
-    valuesToOutput,
-}: FormProps): React.ReactElement {
+export function TargetGroupForm({ id, scope, additionalFormFields, dataToInitialValues, nodeFragment }: FormProps): React.ReactElement {
     const stackApi = useStackApi();
     const client = useApolloClient();
     const mode = id ? "edit" : "add";
@@ -103,13 +95,9 @@ export function TargetGroupForm({
             throw new Error("Conflicts detected");
         }
 
-        let output = {
+        const output = {
             ...state,
         };
-
-        if (valuesToOutput) {
-            output = { title: output.title, ...valuesToOutput(output) };
-        }
 
         if (mode === "edit") {
             if (!id) {

--- a/packages/admin/src/targetGroups/TargetGroupForm.tsx
+++ b/packages/admin/src/targetGroups/TargetGroupForm.tsx
@@ -34,12 +34,8 @@ import {
     GQLUpdateTargetGroupMutationVariables,
 } from "./TargetGroupForm.gql.generated";
 
-type FormValues = {
-    title: string;
-    [key: string]: unknown;
-};
-
 export interface EditTargetGroupFinalFormValues {
+    title: string;
     [key: string]: unknown;
 }
 
@@ -55,7 +51,7 @@ export function TargetGroupForm({ id, scope, additionalFormFields, dataToInitial
     const stackApi = useStackApi();
     const client = useApolloClient();
     const mode = id ? "edit" : "add";
-    const formApiRef = useFormApiRef<FormValues>();
+    const formApiRef = useFormApiRef<EditTargetGroupFinalFormValues>();
     const stackSwitchApi = useStackSwitchApi();
 
     const targetGroupFormFragment = gql`
@@ -71,7 +67,7 @@ export function TargetGroupForm({ id, scope, additionalFormFields, dataToInitial
         id ? { variables: { id } } : { skip: true },
     );
 
-    const initialValues = React.useMemo<Partial<FormValues>>(() => {
+    const initialValues = React.useMemo<Partial<EditTargetGroupFinalFormValues>>(() => {
         let additionalInitialValues = {};
 
         if (dataToInitialValues) {
@@ -92,7 +88,11 @@ export function TargetGroupForm({ id, scope, additionalFormFields, dataToInitial
         },
     });
 
-    const handleSubmit = async (state: FormValues, form: FormApi<FormValues>, event: FinalFormSubmitEvent) => {
+    const handleSubmit = async (
+        state: EditTargetGroupFinalFormValues,
+        form: FormApi<EditTargetGroupFinalFormValues>,
+        event: FinalFormSubmitEvent,
+    ) => {
         if (await saveConflict.checkForConflicts()) {
             throw new Error("Conflicts detected");
         }
@@ -132,7 +132,7 @@ export function TargetGroupForm({ id, scope, additionalFormFields, dataToInitial
     }
 
     return (
-        <FinalForm<FormValues>
+        <FinalForm<EditTargetGroupFinalFormValues>
             apiRef={formApiRef}
             onSubmit={handleSubmit}
             mode={mode}

--- a/packages/admin/src/targetGroups/TargetGroupsPage.tsx
+++ b/packages/admin/src/targetGroups/TargetGroupsPage.tsx
@@ -1,16 +1,27 @@
 import { Stack, StackPage, StackSwitch } from "@comet/admin";
 import { useContentScope } from "@comet/cms-admin";
+import { DocumentNode } from "graphql";
 import * as React from "react";
 import { useIntl } from "react-intl";
 
-import { TargetGroupForm } from "./TargetGroupForm";
+import { EditTargetGroupFinalFormValues, TargetGroupForm } from "./TargetGroupForm";
 import { TargetGroupsGrid } from "./TargetGroupsGrid";
 
 interface CreateContactsPageOptions {
     scopeParts: string[];
+    additionalFormFields?: React.ReactNode;
+    nodeFragment?: { name: string; fragment: DocumentNode };
+    dataToInitialValues?: (values?: EditTargetGroupFinalFormValues) => EditTargetGroupFinalFormValues;
+    valuesToOutput?: (values: EditTargetGroupFinalFormValues) => EditTargetGroupFinalFormValues;
 }
 
-export function createTargetGroupsPage({ scopeParts }: CreateContactsPageOptions) {
+export function createTargetGroupsPage({
+    scopeParts,
+    additionalFormFields,
+    nodeFragment,
+    dataToInitialValues,
+    valuesToOutput,
+}: CreateContactsPageOptions) {
     function TargetGroupsPage(): JSX.Element {
         const { scope: completeScope } = useContentScope();
         const intl = useIntl();
@@ -30,13 +41,28 @@ export function createTargetGroupsPage({ scopeParts }: CreateContactsPageOptions
                         name="edit"
                         title={intl.formatMessage({ id: "cometBrevoModule.targetGroups.editTargetGroup", defaultMessage: "Edit target group" })}
                     >
-                        {(selectedId) => <TargetGroupForm id={selectedId} scope={scope} />}
+                        {(selectedId) => (
+                            <TargetGroupForm
+                                id={selectedId}
+                                scope={scope}
+                                additionalFormFields={additionalFormFields}
+                                nodeFragment={nodeFragment}
+                                dataToInitialValues={dataToInitialValues}
+                                valuesToOutput={valuesToOutput}
+                            />
+                        )}
                     </StackPage>
                     <StackPage
                         name="add"
                         title={intl.formatMessage({ id: "cometBrevoModule.targetGroups.addTargetGroup", defaultMessage: "Add target group" })}
                     >
-                        <TargetGroupForm scope={scope} />
+                        <TargetGroupForm
+                            scope={scope}
+                            additionalFormFields={additionalFormFields}
+                            nodeFragment={nodeFragment}
+                            dataToInitialValues={dataToInitialValues}
+                            valuesToOutput={valuesToOutput}
+                        />
                     </StackPage>
                 </StackSwitch>
             </Stack>

--- a/packages/admin/src/targetGroups/TargetGroupsPage.tsx
+++ b/packages/admin/src/targetGroups/TargetGroupsPage.tsx
@@ -11,11 +11,11 @@ interface CreateContactsPageOptions {
     scopeParts: string[];
     additionalFormFields?: React.ReactNode;
     nodeFragment?: { name: string; fragment: DocumentNode };
-    dataToInitialValues?: (values?: EditTargetGroupFinalFormValues) => EditTargetGroupFinalFormValues;
+    input2State?: (values?: EditTargetGroupFinalFormValues) => EditTargetGroupFinalFormValues;
     valuesToOutput?: (values: EditTargetGroupFinalFormValues) => EditTargetGroupFinalFormValues;
 }
 
-export function createTargetGroupsPage({ scopeParts, additionalFormFields, nodeFragment, dataToInitialValues }: CreateContactsPageOptions) {
+export function createTargetGroupsPage({ scopeParts, additionalFormFields, nodeFragment, input2State }: CreateContactsPageOptions) {
     function TargetGroupsPage(): JSX.Element {
         const { scope: completeScope } = useContentScope();
         const intl = useIntl();
@@ -41,7 +41,7 @@ export function createTargetGroupsPage({ scopeParts, additionalFormFields, nodeF
                                 scope={scope}
                                 additionalFormFields={additionalFormFields}
                                 nodeFragment={nodeFragment}
-                                dataToInitialValues={dataToInitialValues}
+                                input2State={input2State}
                             />
                         )}
                     </StackPage>
@@ -53,7 +53,7 @@ export function createTargetGroupsPage({ scopeParts, additionalFormFields, nodeF
                             scope={scope}
                             additionalFormFields={additionalFormFields}
                             nodeFragment={nodeFragment}
-                            dataToInitialValues={dataToInitialValues}
+                            input2State={input2State}
                         />
                     </StackPage>
                 </StackSwitch>

--- a/packages/admin/src/targetGroups/TargetGroupsPage.tsx
+++ b/packages/admin/src/targetGroups/TargetGroupsPage.tsx
@@ -15,13 +15,7 @@ interface CreateContactsPageOptions {
     valuesToOutput?: (values: EditTargetGroupFinalFormValues) => EditTargetGroupFinalFormValues;
 }
 
-export function createTargetGroupsPage({
-    scopeParts,
-    additionalFormFields,
-    nodeFragment,
-    dataToInitialValues,
-    valuesToOutput,
-}: CreateContactsPageOptions) {
+export function createTargetGroupsPage({ scopeParts, additionalFormFields, nodeFragment, dataToInitialValues }: CreateContactsPageOptions) {
     function TargetGroupsPage(): JSX.Element {
         const { scope: completeScope } = useContentScope();
         const intl = useIntl();
@@ -48,7 +42,6 @@ export function createTargetGroupsPage({
                                 additionalFormFields={additionalFormFields}
                                 nodeFragment={nodeFragment}
                                 dataToInitialValues={dataToInitialValues}
-                                valuesToOutput={valuesToOutput}
                             />
                         )}
                     </StackPage>
@@ -61,7 +54,6 @@ export function createTargetGroupsPage({
                             additionalFormFields={additionalFormFields}
                             nodeFragment={nodeFragment}
                             dataToInitialValues={dataToInitialValues}
-                            valuesToOutput={valuesToOutput}
                         />
                     </StackPage>
                 </StackSwitch>


### PR DESCRIPTION
depends on #29 

This adds configurable fields to the target group form 

With configuration (code in this PR):
<img width="1726" alt="Screenshot 2024-01-26 at 11 20 42" src="https://github.com/vivid-planet/comet-brevo-module/assets/16517335/368a7813-38d7-4793-b183-bab9870b9b78">

Without configuration the filters section will not be rendered:
<img width="1725" alt="Screenshot 2024-01-26 at 11 22 13" src="https://github.com/vivid-planet/comet-brevo-module/assets/16517335/3392d7b3-50a0-42a9-942b-24e4c3a2cfbf">


This is part of COM-271


