### PR TITLE
COM-343: Add additional functionality to email campaign admin (send now & test emails)

### DIFF
--- a/packages/admin/src/emailCampaigns/form/EmailCampaignForm.tsx
+++ b/packages/admin/src/emailCampaigns/form/EmailCampaignForm.tsx
@@ -52,6 +52,7 @@ import {
     GQLUpdateEmailCampaignMutationVariables,
 } from "./EmailCampaignForm.gql.generated";
 import { SendManagerFields } from "./SendManagerFields";
+import { TestEmailCampaignForm } from "./TestEmailCampaignForm";
 
 interface FormProps {
     id?: string;
@@ -288,6 +289,7 @@ export function EmailCampaignForm({ id, EmailCampaignContentBlock, scope, previe
                                     }}
                                 >
                                     <SendManagerFields scope={scope} disableScheduling={isScheduleDateDisabled} />
+                                    <TestEmailCampaignForm id={id} isSendable={!hasChanges && state.targetGroup != undefined} />
                                 </BlocksFinalForm>
                             ),
                         },

--- a/packages/admin/src/emailCampaigns/form/EmailCampaignForm.tsx
+++ b/packages/admin/src/emailCampaigns/form/EmailCampaignForm.tsx
@@ -288,7 +288,12 @@ export function EmailCampaignForm({ id, EmailCampaignContentBlock, scope, previe
                                         scheduledAt: state.scheduledAt,
                                     }}
                                 >
-                                    <SendManagerFields scope={scope} disableScheduling={isScheduleDateDisabled} />
+                                    <SendManagerFields
+                                        scope={scope}
+                                        disableScheduling={isScheduleDateDisabled}
+                                        isSendable={!hasChanges && state.targetGroup != undefined}
+                                        id={id}
+                                    />
                                     <TestEmailCampaignForm id={id} isSendable={!hasChanges && state.targetGroup != undefined} />
                                 </BlocksFinalForm>
                             ),

--- a/packages/admin/src/emailCampaigns/form/SendEmailCampaignNowDialog.tsx
+++ b/packages/admin/src/emailCampaigns/form/SendEmailCampaignNowDialog.tsx
@@ -1,0 +1,34 @@
+import { CancelButton, SaveButton } from "@comet/admin";
+import { Dialog, DialogActions, DialogContent, DialogTitle } from "@mui/material";
+import React from "react";
+import { FormattedMessage } from "react-intl";
+
+interface SendEmailCampaignNowDialogProps {
+    dialogOpen: boolean;
+    handleNoClick: () => void;
+    handleYesClick: () => void;
+}
+
+const SendEmailCampaignNowDialog = ({ dialogOpen, handleNoClick, handleYesClick }: SendEmailCampaignNowDialogProps) => {
+    return (
+        <Dialog open={dialogOpen} onClose={handleNoClick}>
+            <DialogTitle>
+                <FormattedMessage id="cometBrevoModule.emailCampaigns.sendNow.dialog.title" defaultMessage="Send email campaign now?" />
+            </DialogTitle>
+            <DialogContent>
+                <FormattedMessage
+                    id="cometBrevoModule.emailCampaigns.sendNow.dialog.contentText"
+                    defaultMessage="Are you sure you want to send the email campaign now?"
+                />
+            </DialogContent>
+            <DialogActions>
+                <CancelButton onClick={handleNoClick} />
+                <SaveButton onClick={handleYesClick}>
+                    <FormattedMessage id="cometBrevoModule.emailCampaigns.sendNow.dialog.sendText" defaultMessage="Send now" />
+                </SaveButton>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export { SendEmailCampaignNowDialog };

--- a/packages/admin/src/emailCampaigns/form/SendManagerFields.gql.ts
+++ b/packages/admin/src/emailCampaigns/form/SendManagerFields.gql.ts
@@ -10,3 +10,9 @@ export const targetGroupsSelectQuery = gql`
         }
     }
 `;
+
+export const sendEmailCampaignNowMutation = gql`
+    mutation SendEmailCampaignNow($id: ID!) {
+        sendEmailCampaignNow(id: $id)
+    }
+`;

--- a/packages/admin/src/emailCampaigns/form/TestEmailCampaignForm.gql.ts
+++ b/packages/admin/src/emailCampaigns/form/TestEmailCampaignForm.gql.ts
@@ -1,0 +1,7 @@
+import { gql } from "@apollo/client";
+
+export const SendEmailCampaignToTestEmailsMutation = gql`
+    mutation SendEmailCampaignToTestEmails($id: ID!, $data: SendTestEmailCampaignArgs!) {
+        sendEmailCampaignToTestEmails(id: $id, data: $data)
+    }
+`;

--- a/packages/admin/src/emailCampaigns/form/TestEmailCampaignForm.tsx
+++ b/packages/admin/src/emailCampaigns/form/TestEmailCampaignForm.tsx
@@ -1,0 +1,114 @@
+import { useApolloClient } from "@apollo/client";
+import { Field, FinalForm, FinalFormInput, SaveButton } from "@comet/admin";
+import { Newsletter } from "@comet/admin-icons";
+import { AdminComponentPaper, AdminComponentSectionGroup } from "@comet/blocks-admin";
+import { Card, FormHelperText, Typography } from "@mui/material";
+import React from "react";
+import { FormattedMessage } from "react-intl";
+
+import { SendEmailCampaignToTestEmailsMutation } from "./TestEmailCampaignForm.gql";
+import { GQLSendEmailCampaignToTestEmailsMutation, GQLSendEmailCampaignToTestEmailsMutationVariables } from "./TestEmailCampaignForm.gql.generated";
+
+interface FormProps {
+    testEmails: string;
+}
+
+interface TestEmailCampaignFormProps {
+    id?: string;
+    isSendable?: boolean;
+}
+
+export const TestEmailCampaignForm = ({ id, isSendable = false }: TestEmailCampaignFormProps) => {
+    const client = useApolloClient();
+
+    async function submitTestEmails({ testEmails }: FormProps) {
+        const emailsArray = testEmails.trim().split("\n");
+
+        if (id) {
+            const { data } = await client.mutate<GQLSendEmailCampaignToTestEmailsMutation, GQLSendEmailCampaignToTestEmailsMutationVariables>({
+                mutation: SendEmailCampaignToTestEmailsMutation,
+                variables: { id, data: { emails: emailsArray } },
+            });
+            return data?.sendEmailCampaignToTestEmails;
+        }
+    }
+
+    return (
+        <Card sx={{ mt: 4 }}>
+            <AdminComponentPaper>
+                <AdminComponentSectionGroup
+                    title={
+                        <FormattedMessage id="cometBrevoModule.emailCampaigns.testEmailCampaign.title" defaultMessage="Send test email campaign" />
+                    }
+                >
+                    <FinalForm<FormProps>
+                        mode="edit"
+                        onSubmit={submitTestEmails}
+                        onAfterSubmit={() => {
+                            // override default behavior
+                        }}
+                    >
+                        {({ handleSubmit, submitting, values }) => {
+                            return (
+                                <>
+                                    <Field
+                                        name="testEmails"
+                                        label={
+                                            <FormattedMessage
+                                                id="cometBrevoModule.emailCampaigns.testEmailCampaign.testEmails"
+                                                defaultMessage="Email addresses"
+                                            />
+                                        }
+                                        component={FinalFormInput}
+                                        multiline
+                                        placeholder={["First test email address", "Second test email address"].join("\n")}
+                                        fullWidth
+                                        minRows={4}
+                                    />
+                                    <FormHelperText sx={{ marginTop: -2, marginBottom: 4 }}>
+                                        <Typography sx={{ display: "flex", alignItems: "center" }}>
+                                            <FormattedMessage
+                                                id="cometBrevoModule.emailCampaigns.testEmailCampaign.oneEmailAddressEachLine"
+                                                defaultMessage="One email address each line"
+                                            />
+                                        </Typography>
+                                        <Typography />
+                                    </FormHelperText>
+                                    <SaveButton
+                                        disabled={!values.testEmails || !isSendable || !id}
+                                        saveIcon={<Newsletter />}
+                                        onClick={handleSubmit}
+                                        saving={submitting}
+                                        errorItem={
+                                            <FormattedMessage
+                                                id="cometBrevoModule.emailCampaigns.testEmailCampaign.errorText"
+                                                defaultMessage="There was an error sending the email campaign to the test addresses."
+                                            />
+                                        }
+                                        successItem={
+                                            <FormattedMessage
+                                                id="cometBrevoModule.emailCampaigns.testEmailCampaign.successText"
+                                                defaultMessage="Test email campaign was sent successfully."
+                                            />
+                                        }
+                                        savingItem={
+                                            <FormattedMessage
+                                                id="cometBrevoModule.emailCampaigns.testEmailCampaign.sendingText"
+                                                defaultMessage="Sending..."
+                                            />
+                                        }
+                                    >
+                                        <FormattedMessage
+                                            id="cometBrevoModule.emailCampaigns.testEmailCampaign.sendText"
+                                            defaultMessage="Send test email campaign"
+                                        />
+                                    </SaveButton>
+                                </>
+                            );
+                        }}
+                    </FinalForm>
+                </AdminComponentSectionGroup>
+            </AdminComponentPaper>
+        </Card>
+    );
+};

--- a/packages/api/src/email-campaign/email-campaign.resolver.ts
+++ b/packages/api/src/email-campaign/email-campaign.resolver.ts
@@ -173,7 +173,21 @@ export function createEmailCampaignsResolver({
 
         @Mutation(() => Boolean)
         async sendEmailCampaignNow(@Args("id", { type: () => ID }) id: string): Promise<boolean> {
-            return this.campaignsService.sendEmailCampaignNow(id);
+            const campaignSent = await this.campaignsService.sendEmailCampaignNow(id);
+
+            if (campaignSent) {
+                const campaign = await this.repository.findOneOrFail(id);
+
+                wrap(campaign).assign({
+                    scheduledAt: new Date(),
+                });
+
+                await this.entityManager.flush();
+
+                return true;
+            }
+
+            return false;
         }
 
         @Mutation(() => Boolean)

--- a/packages/api/src/email-campaign/email-campaigns.service.ts
+++ b/packages/api/src/email-campaign/email-campaigns.service.ts
@@ -125,6 +125,6 @@ export class EmailCampaignsService {
             } while (currentOffset < totalContacts);
         }
 
-        return campaign.brevoId ? this.brevoApiCampaignService.sendBrevoCampaign(campaign.brevoId) : false;
+        return false;
     }
 }


### PR DESCRIPTION
depends on #32 

![Screenshot 2024-02-02 at 13 19 20](https://github.com/vivid-planet/comet-brevo-module/assets/16517335/95cb870c-a50b-4aad-b1a7-4bf174f8fb24)


This is part of COM-343