### PR TITLE
fix send brevo campaign now: send the brevo campaign when all contacts are checked with the ecgRtrList check

### DIFF
--- a/packages/api/src/email-campaign/email-campaigns.service.ts
+++ b/packages/api/src/email-campaign/email-campaigns.service.ts
@@ -116,13 +116,13 @@ export class EmailCampaignsService {
                     await this.brevoApiContactsService.blacklistMultipleContacts(containedEmails);
                 }
 
-                if (campaign.brevoId) {
-                    return this.brevoApiCampaignService.sendBrevoCampaign(campaign.brevoId);
-                }
-
                 currentOffset += limit;
                 totalContacts = total;
             } while (currentOffset < totalContacts);
+
+            if (campaign.brevoId) {
+                return this.brevoApiCampaignService.sendBrevoCampaign(campaign.brevoId);
+            }
         }
 
         return false;


### PR DESCRIPTION
The campaign should only be sent after all contacts are checked and blacklisted (in case of being in the ecgRtrList) and not in the while loop