### PR TITLE
Add email campaign scope for preview

### DIFF
--- a/.changeset/grumpy-dryers-fetch.md
+++ b/.changeset/grumpy-dryers-fetch.md
@@ -1,0 +1,7 @@
+---
+"@comet/brevo-admin": minor
+---
+
+Add `scope` in `previewState` for the `EmailCampaignView`
+
+This can be useful for example when applications have different styling depending on the scope.

--- a/packages/admin/src/emailCampaigns/view/EmailCampaignView.tsx
+++ b/packages/admin/src/emailCampaigns/view/EmailCampaignView.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@apollo/client";
 import { Loading, MainContent, Toolbar, ToolbarFillSpace, ToolbarItem, ToolbarTitleItem, useStackApi } from "@comet/admin";
 import { ArrowLeft } from "@comet/admin-icons";
 import { BlockInterface, IFrameBridgeProvider } from "@comet/blocks-admin";
-import { BlockPreview, EditPageLayout, useBlockPreview, useCmsBlockContext } from "@comet/cms-admin";
+import { BlockPreview, EditPageLayout, useBlockPreview, useCmsBlockContext, useContentScope } from "@comet/cms-admin";
 import { IconButton } from "@mui/material";
 import React from "react";
 import { FormattedMessage } from "react-intl";
@@ -22,6 +22,7 @@ export function EmailCampaignView({ id, EmailCampaignContentBlock, previewUrl }:
     const previewApi = useBlockPreview();
     const blockContext = useCmsBlockContext();
     const match = useRouteMatch();
+    const { scope } = useContentScope();
 
     const { data, error, loading } = useQuery<GQLEmailCampaignViewQuery, GQLEmailCampaignViewQueryVariables>(emailCampaignViewQuery, {
         variables: { id },
@@ -46,6 +47,7 @@ export function EmailCampaignView({ id, EmailCampaignContentBlock, previewUrl }:
     const previewState = {
         emailCampaignId: id,
         content: EmailCampaignContentBlock.createPreviewState(EmailCampaignContentBlock.input2State(data.emailCampaign.content), previewContext),
+        scope,
     };
 
     return (


### PR DESCRIPTION
-   [x] Add changeset (if necessary)

Is already here:
https://github.com/vivid-planet/comet-brevo-module/blob/main/packages/admin/src/emailCampaigns/form/EmailCampaignForm.tsx#L213

But was missing in the EmailCampaignView.

This is needed when applications have different styling depending on the scope.
