### PR TITLE
COM-908 Add test contact list

### DIFF
--- a/.changeset/chilly-dogs-draw.md
+++ b/.changeset/chilly-dogs-draw.md
@@ -1,0 +1,6 @@
+---
+"@comet/brevo-admin": major
+"@comet/brevo-api": major
+---
+
+Add test contact page

--- a/.changeset/chilly-dogs-draw.md
+++ b/.changeset/chilly-dogs-draw.md
@@ -1,6 +1,6 @@
 ---
-"@comet/brevo-admin": major
-"@comet/brevo-api": major
+"@comet/brevo-admin": minor
+"@comet/brevo-api": minor
 ---
 
 Adds `createBrevoTestContactsPage` for creating a test contacts page, that is indepent from the main list.

--- a/.changeset/chilly-dogs-draw.md
+++ b/.changeset/chilly-dogs-draw.md
@@ -3,4 +3,6 @@
 "@comet/brevo-api": major
 ---
 
-Add test contact page
+Adds `createBrevoTestContactsPage` for creating a test contacts page, that is indepent from the main list.
+
+Remove `email` and `redirectionUrl` from `brevoContactsPageAttributesConfig`

--- a/demo/admin/src/Routes.tsx
+++ b/demo/admin/src/Routes.tsx
@@ -1,6 +1,6 @@
 import { MasterLayout, RouteWithErrorBoundary } from "@comet/admin";
 import { Domain } from "@comet/admin-icons";
-import { createBrevoContactsPage, createEmailCampaignsPage, createTargetGroupsPage } from "@comet/brevo-admin";
+import { createBrevoContactsPage, createBrevoTestContactsPage, createEmailCampaignsPage, createTargetGroupsPage } from "@comet/brevo-admin";
 import { ContentScopeIndicator, createRedirectsPage, DamPage, PagesPage, PublisherPage, SitePreview } from "@comet/cms-admin";
 import { getBrevoContactConfig } from "@src/common/brevoModuleConfig/brevoContactsPageAttributesConfig";
 import { pageTreeCategories, urlParamToCategory } from "@src/pageTree/pageTreeCategories";
@@ -33,7 +33,7 @@ export const Routes: React.FC = () => {
         input2State: brevoContactConfig.input2State,
     });
 
-    const BrevoTestContactsPage = createBrevoContactsPage({
+    const BrevoTestContactsPage = createBrevoTestContactsPage({
         scopeParts: ["domain", "language"],
         additionalAttributesFragment: brevoContactConfig.additionalAttributesFragment,
         additionalGridFields: brevoContactConfig.additionalGridFields,

--- a/demo/admin/src/Routes.tsx
+++ b/demo/admin/src/Routes.tsx
@@ -33,6 +33,14 @@ export const Routes: React.FC = () => {
         input2State: brevoContactConfig.input2State,
     });
 
+    const BrevoTestContactsPage = createBrevoContactsPage({
+        scopeParts: ["domain", "language"],
+        additionalAttributesFragment: brevoContactConfig.additionalAttributesFragment,
+        additionalGridFields: brevoContactConfig.additionalGridFields,
+        additionalFormFields: brevoContactConfig.additionalFormFields,
+        input2State: brevoContactConfig.input2State,
+    });
+
     const TargetGroupsPage = createTargetGroupsPage({
         scopeParts: ["domain", "language"],
         additionalFormFields: additionalFormConfig.additionalFormFields,
@@ -94,6 +102,7 @@ export const Routes: React.FC = () => {
                                     />
 
                                     <RouteWithErrorBoundary path={`${match.path}/newsletter/contacts`} component={BrevoContactsPage} />
+                                    <RouteWithErrorBoundary path={`${match.path}/newsletter/test-contacts`} component={BrevoTestContactsPage} />
                                     <RouteWithErrorBoundary path={`${match.path}/newsletter/target-groups`} component={TargetGroupsPage} />
                                     <RouteWithErrorBoundary path={`${match.path}/newsletter/email-campaigns`} component={EmailCampaignsPage} />
 

--- a/demo/admin/src/common/MasterMenu.tsx
+++ b/demo/admin/src/common/MasterMenu.tsx
@@ -41,6 +41,10 @@ export const MasterMenu: React.FC = () => {
                     to={`${match.url}/newsletter/contacts`}
                 />
                 <MenuItemRouterLink
+                    primary={intl.formatMessage({ id: "menu.newsletter.testContacts", defaultMessage: "Test contacts" })}
+                    to={`${match.url}/newsletter/test-contacts`}
+                />
+                <MenuItemRouterLink
                     primary={intl.formatMessage({ id: "menu.newsletter.targetGroups", defaultMessage: "Target groups" })}
                     to={`${match.url}/newsletter/target-groups`}
                 />

--- a/demo/admin/src/common/brevoModuleConfig/brevoContactsPageAttributesConfig.tsx
+++ b/demo/admin/src/common/brevoModuleConfig/brevoContactsPageAttributesConfig.tsx
@@ -70,7 +70,7 @@ export const getBrevoContactConfig = (
         name: string;
     };
     input2State: (values?: AdditionalFormConfigInputProps) => {
-        attributes: { SALUTATION?: GQLBrevoContactSalutation; FIRSTNAME?: string; LASTNAME?: string };
+        attributes: { BRANCH?: Array<GQLBrevoContactBranch>; SALUTATION?: GQLBrevoContactSalutation; FIRSTNAME?: string; LASTNAME?: string };
     };
     exportFields: {
         renderValue: (row: GQLBrevoContactAttributesFragmentFragment) => string;

--- a/demo/admin/src/common/brevoModuleConfig/brevoContactsPageAttributesConfig.tsx
+++ b/demo/admin/src/common/brevoModuleConfig/brevoContactsPageAttributesConfig.tsx
@@ -138,10 +138,9 @@ export const getBrevoContactConfig = (
                 />
             </>
         ),
-        input2State: (values?: AdditionalFormConfigInputProps) => {
+        input2State: (values: AdditionalFormConfigInputProps) => {
             return {
-                email: values?.email ?? "",
-                redirectionUrl: values?.redirectionUrl ?? "",
+                ...values,
                 attributes: {
                     BRANCH: values?.attributes?.BRANCH ?? [],
                     SALUTATION: values?.attributes?.SALUTATION,

--- a/demo/admin/src/common/brevoModuleConfig/brevoContactsPageAttributesConfig.tsx
+++ b/demo/admin/src/common/brevoModuleConfig/brevoContactsPageAttributesConfig.tsx
@@ -70,9 +70,7 @@ export const getBrevoContactConfig = (
         name: string;
     };
     input2State: (values?: AdditionalFormConfigInputProps) => {
-        email: string;
-        redirectionUrl: string;
-        attributes: { BRANCH?: Array<GQLBrevoContactBranch>; SALUTATION?: GQLBrevoContactSalutation; FIRSTNAME?: string; LASTNAME?: string };
+        attributes: { SALUTATION?: GQLBrevoContactSalutation; FIRSTNAME?: string; LASTNAME?: string };
     };
     exportFields: {
         renderValue: (row: GQLBrevoContactAttributesFragmentFragment) => string;
@@ -140,7 +138,6 @@ export const getBrevoContactConfig = (
         ),
         input2State: (values: AdditionalFormConfigInputProps) => {
             return {
-                ...values,
                 attributes: {
                     BRANCH: values?.attributes?.BRANCH ?? [],
                     SALUTATION: values?.attributes?.SALUTATION,

--- a/demo/admin/src/common/brevoModuleConfig/brevoContactsPageAttributesConfig.tsx
+++ b/demo/admin/src/common/brevoModuleConfig/brevoContactsPageAttributesConfig.tsx
@@ -136,7 +136,7 @@ export const getBrevoContactConfig = (
                 />
             </>
         ),
-        input2State: (values: AdditionalFormConfigInputProps) => {
+        input2State: (values?: AdditionalFormConfigInputProps) => {
             return {
                 attributes: {
                     BRANCH: values?.attributes?.BRANCH ?? [],

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -742,7 +742,7 @@ type Mutation {
   deleteDamFolder(id: ID!): Boolean!
   updateBrevoContact(id: Int!, scope: EmailCampaignContentScopeInput!, input: BrevoContactUpdateInput!): BrevoContact!
   createBrevoContact(scope: EmailCampaignContentScopeInput!, input: BrevoContactInput!): SubscribeResponse!
-  createBrevoTestContact(scope: EmailCampaignContentScopeInput!, input: BrevoContactInput!): SubscribeResponse!
+  createBrevoTestContact(scope: EmailCampaignContentScopeInput!, input: BrevoTestContactInput!): SubscribeResponse!
   deleteBrevoContact(id: Int!, scope: EmailCampaignContentScopeInput!): Boolean!
   deleteBrevoTestContact(id: Int!, scope: EmailCampaignContentScopeInput!): Boolean!
   subscribeBrevoContact(input: SubscribeInput!, scope: EmailCampaignContentScopeInput!): SubscribeResponse!
@@ -898,6 +898,12 @@ input BrevoContactInput {
   email: String!
   blocked: Boolean!
   redirectionUrl: String!
+  attributes: BrevoContactAttributesInput
+}
+
+input BrevoTestContactInput {
+  email: String!
+  blocked: Boolean!
   attributes: BrevoContactAttributesInput
 }
 

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -411,6 +411,7 @@ type TargetGroup implements DocumentInterface {
   createdAt: DateTime!
   title: String!
   isMainList: Boolean!
+  isTestList: Boolean
   brevoId: Int!
   totalSubscribers: Int!
   totalContactsBlocked: Int!

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -744,6 +744,7 @@ type Mutation {
   createBrevoContact(scope: EmailCampaignContentScopeInput!, input: BrevoContactInput!): SubscribeResponse!
   createBrevoTestContact(scope: EmailCampaignContentScopeInput!, input: BrevoContactInput!): SubscribeResponse!
   deleteBrevoContact(id: Int!, scope: EmailCampaignContentScopeInput!): Boolean!
+  deleteBrevoTestContact(id: Int!, scope: EmailCampaignContentScopeInput!): Boolean!
   subscribeBrevoContact(input: SubscribeInput!, scope: EmailCampaignContentScopeInput!): SubscribeResponse!
   createEmailCampaign(scope: EmailCampaignContentScopeInput!, input: EmailCampaignInput!): EmailCampaign!
   updateEmailCampaign(id: ID!, input: EmailCampaignUpdateInput!, lastUpdatedAt: DateTime): EmailCampaign!

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -528,6 +528,7 @@ type Query {
   mainMenu(scope: PageTreeNodeScopeInput!): [PageTreeNode!]!
   brevoContact(id: Int!, scope: EmailCampaignContentScopeInput!): BrevoContact!
   brevoContacts(targetGroupId: ID, email: String, scope: EmailCampaignContentScopeInput!, offset: Int! = 0, limit: Int! = 25): PaginatedBrevoContacts!
+  brevoTestContacts(targetGroupId: ID, email: String, scope: EmailCampaignContentScopeInput!, offset: Int! = 0, limit: Int! = 25): PaginatedBrevoContacts!
   manuallyAssignedBrevoContacts(offset: Int! = 0, limit: Int! = 25, targetGroupId: ID!, email: String): PaginatedBrevoContacts!
   emailCampaign(id: ID!): EmailCampaign!
   emailCampaigns(scope: EmailCampaignContentScopeInput!, search: String, filter: EmailCampaignFilter, sort: [EmailCampaignSort!], offset: Int! = 0, limit: Int! = 25): PaginatedEmailCampaigns!
@@ -739,6 +740,7 @@ type Mutation {
   deleteDamFolder(id: ID!): Boolean!
   updateBrevoContact(id: Int!, scope: EmailCampaignContentScopeInput!, input: BrevoContactUpdateInput!): BrevoContact!
   createBrevoContact(scope: EmailCampaignContentScopeInput!, input: BrevoContactInput!): SubscribeResponse!
+  createBrevoTestContact(scope: EmailCampaignContentScopeInput!, input: BrevoContactInput!): SubscribeResponse!
   deleteBrevoContact(id: Int!, scope: EmailCampaignContentScopeInput!): Boolean!
   subscribeBrevoContact(input: SubscribeInput!, scope: EmailCampaignContentScopeInput!): SubscribeResponse!
   createEmailCampaign(scope: EmailCampaignContentScopeInput!, input: EmailCampaignInput!): EmailCampaign!

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -689,6 +689,7 @@ input TargetGroupFilter {
   createdAt: DateFilter
   updatedAt: DateFilter
   title: StringFilter
+  isTestList: BooleanFilter
   and: [TargetGroupFilter!]
   or: [TargetGroupFilter!]
 }

--- a/packages/admin/src/brevoContacts/form/BrevoContactForm.tsx
+++ b/packages/admin/src/brevoContacts/form/BrevoContactForm.tsx
@@ -45,7 +45,7 @@ export type EditBrevoContactFormValues = {
     [key: string]: unknown;
 };
 
-type BaseBrevoContactFormValues = EditBrevoContactFormValues & {
+type EditBrevoContactFormValuesWithAttributes = EditBrevoContactFormValues & {
     email: string;
     redirectionUrl: string;
 };
@@ -62,7 +62,7 @@ export function BrevoContactForm({ id, scope, input2State, additionalFormFields,
     const stackApi = useStackApi();
     const client = useApolloClient();
     const mode = id ? "edit" : "add";
-    const formApiRef = useFormApiRef<BaseBrevoContactFormValues>();
+    const formApiRef = useFormApiRef<EditBrevoContactFormValuesWithAttributes>();
 
     const brevoContactFormFragment = gql`
         fragment BrevoContactForm on BrevoContact {
@@ -76,7 +76,7 @@ export function BrevoContactForm({ id, scope, input2State, additionalFormFields,
         id ? { variables: { id, scope } } : { skip: true },
     );
 
-    const initialValues = React.useMemo<Partial<BaseBrevoContactFormValues>>(() => {
+    const initialValues = React.useMemo<Partial<EditBrevoContactFormValuesWithAttributes>>(() => {
         let baseInitialValues = {
             email: "",
             redirectionUrl: "",
@@ -114,7 +114,11 @@ export function BrevoContactForm({ id, scope, input2State, additionalFormFields,
         },
     });
 
-    const handleSubmit = async (state: BaseBrevoContactFormValues, form: FormApi<BaseBrevoContactFormValues>, event: FinalFormSubmitEvent) => {
+    const handleSubmit = async (
+        state: EditBrevoContactFormValuesWithAttributes,
+        form: FormApi<EditBrevoContactFormValuesWithAttributes>,
+        event: FinalFormSubmitEvent,
+    ) => {
         if (await saveConflict.checkForConflicts()) {
             throw new Error("Conflicts detected");
         }
@@ -161,7 +165,7 @@ export function BrevoContactForm({ id, scope, input2State, additionalFormFields,
     }
 
     return (
-        <FinalForm<BaseBrevoContactFormValues> apiRef={formApiRef} onSubmit={handleSubmit} mode={mode} initialValues={initialValues}>
+        <FinalForm<EditBrevoContactFormValuesWithAttributes> apiRef={formApiRef} onSubmit={handleSubmit} mode={mode} initialValues={initialValues}>
             {({ values }) => (
                 <EditPageLayout>
                     {saveConflict.dialogs}

--- a/packages/admin/src/brevoContacts/form/BrevoContactForm.tsx
+++ b/packages/admin/src/brevoContacts/form/BrevoContactForm.tsx
@@ -42,9 +42,13 @@ import {
 } from "./BrevoContactForm.gql.generated";
 
 export type EditBrevoContactFormValues = {
+    [key: string]: unknown;
+};
+
+type BaseBrevoContactFormValues = EditBrevoContactFormValues & {
+    //Umbenennen
     email: string;
     redirectionUrl: string;
-    [key: string]: unknown;
 };
 
 interface FormProps {
@@ -59,14 +63,11 @@ export function BrevoContactForm({ id, scope, input2State, additionalFormFields,
     const stackApi = useStackApi();
     const client = useApolloClient();
     const mode = id ? "edit" : "add";
-    const formApiRef = useFormApiRef<EditBrevoContactFormValues>();
+    const formApiRef = useFormApiRef<BaseBrevoContactFormValues>();
 
     const brevoContactFormFragment = gql`
         fragment BrevoContactForm on BrevoContact {
             email
-            createdAt
-            emailBlacklisted
-            smsBlacklisted
             ${additionalAttributesFragment ? "...".concat(additionalAttributesFragment?.name) : ""}
         }
         ${additionalAttributesFragment?.fragment ?? ""}
@@ -76,11 +77,15 @@ export function BrevoContactForm({ id, scope, input2State, additionalFormFields,
         id ? { variables: { id, scope } } : { skip: true },
     );
 
-    const initialValues = React.useMemo<Partial<EditBrevoContactFormValues>>(() => {
+    const initialValues = React.useMemo<Partial<BaseBrevoContactFormValues>>(() => {
         let additionalInitialValues = {};
 
         if (input2State) {
-            additionalInitialValues = input2State({ email: "", redirectionUrl: "", ...data?.brevoContact });
+            additionalInitialValues = input2State({
+                email: "",
+                redirectionUrl: "",
+                ...data?.brevoContact,
+            });
         }
         return data?.brevoContact
             ? {
@@ -112,7 +117,7 @@ export function BrevoContactForm({ id, scope, input2State, additionalFormFields,
         },
     });
 
-    const handleSubmit = async (state: EditBrevoContactFormValues, form: FormApi<EditBrevoContactFormValues>, event: FinalFormSubmitEvent) => {
+    const handleSubmit = async (state: BaseBrevoContactFormValues, form: FormApi<BaseBrevoContactFormValues>, event: FinalFormSubmitEvent) => {
         if (await saveConflict.checkForConflicts()) {
             throw new Error("Conflicts detected");
         }
@@ -159,7 +164,7 @@ export function BrevoContactForm({ id, scope, input2State, additionalFormFields,
     }
 
     return (
-        <FinalForm<EditBrevoContactFormValues> apiRef={formApiRef} onSubmit={handleSubmit} mode={mode} initialValues={initialValues}>
+        <FinalForm<BaseBrevoContactFormValues> apiRef={formApiRef} onSubmit={handleSubmit} mode={mode} initialValues={initialValues}>
             {({ values }) => (
                 <EditPageLayout>
                     {saveConflict.dialogs}

--- a/packages/admin/src/brevoContacts/form/BrevoContactForm.tsx
+++ b/packages/admin/src/brevoContacts/form/BrevoContactForm.tsx
@@ -46,7 +46,6 @@ export type EditBrevoContactFormValues = {
 };
 
 type BaseBrevoContactFormValues = EditBrevoContactFormValues & {
-    //Umbenennen
     email: string;
     redirectionUrl: string;
 };

--- a/packages/admin/src/brevoContacts/form/BrevoContactForm.tsx
+++ b/packages/admin/src/brevoContacts/form/BrevoContactForm.tsx
@@ -77,21 +77,19 @@ export function BrevoContactForm({ id, scope, input2State, additionalFormFields,
     );
 
     const initialValues = React.useMemo<Partial<BaseBrevoContactFormValues>>(() => {
-        let additionalInitialValues = {};
+        let baseInitialValues = {
+            email: "",
+            redirectionUrl: "",
+        };
 
         if (input2State) {
-            additionalInitialValues = input2State({
-                email: "",
-                redirectionUrl: "",
-                ...data?.brevoContact,
-            });
+            baseInitialValues = {
+                ...baseInitialValues,
+                ...input2State(data?.brevoContact),
+            };
         }
-        return data?.brevoContact
-            ? {
-                  email: data.brevoContact.email,
-                  ...additionalInitialValues,
-              }
-            : additionalInitialValues;
+
+        return data?.brevoContact?.email ? { ...baseInitialValues, email: data.brevoContact.email } : baseInitialValues;
     }, [data?.brevoContact, input2State]);
 
     const saveConflict = useFormSaveConflict({

--- a/packages/admin/src/brevoTestContacts/BrevoTestContactsGrid.tsx
+++ b/packages/admin/src/brevoTestContacts/BrevoTestContactsGrid.tsx
@@ -1,0 +1,237 @@
+import { DocumentNode, gql, useApolloClient, useQuery } from "@apollo/client";
+import {
+    MainContent,
+    messages,
+    RowActionsItem,
+    RowActionsMenu,
+    StackLink,
+    Toolbar,
+    ToolbarActions,
+    ToolbarFillSpace,
+    ToolbarItem,
+    ToolbarTitleItem,
+    useBufferedRowCount,
+    useDataGridRemote,
+    usePersistentColumnState,
+} from "@comet/admin";
+import { Add, Block, Check, Delete, Edit } from "@comet/admin-icons";
+import { ContentScopeInterface } from "@comet/cms-admin";
+import { Button, IconButton } from "@mui/material";
+import { DataGrid, GridColDef, GridToolbarQuickFilter } from "@mui/x-data-grid";
+import * as React from "react";
+import { FormattedMessage, IntlShape, useIntl } from "react-intl";
+
+import { useContactImportFromCsv } from "../common/contactImport/useContactImportFromCsv";
+import { GQLEmailCampaignContentScopeInput } from "../graphql.generated";
+import { CrudMoreActionsMenu } from "../temp/CrudMoreActionsMenu";
+import {
+    GQLBrevoContactsListFragment,
+    GQLDeleteBrevoContactMutation,
+    GQLDeleteBrevoContactMutationVariables,
+    GQLUpdateBrevoContactMutation,
+    GQLUpdateBrevoContactMutationVariables,
+    namedOperations,
+} from "./BrevoContactsGrid.generated";
+import { GQLBrevoTestContactsGridQuery, GQLBrevoTestContactsGridQueryVariables } from "./BrevoTestContactsGrid.generated";
+
+const brevoContactsFragment = gql`
+    fragment BrevoContactsList on BrevoContact {
+        id
+        createdAt
+        modifiedAt
+        email
+        emailBlacklisted
+        smsBlacklisted
+    }
+`;
+
+const deleteBrevoContactMutation = gql`
+    mutation DeleteBrevoContact($id: Int!, $scope: EmailCampaignContentScopeInput!) {
+        deleteBrevoContact(id: $id, scope: $scope)
+    }
+`;
+
+const updateBrevoContactMutation = gql`
+    mutation UpdateBrevoContact($id: Int!, $input: BrevoContactUpdateInput!, $scope: EmailCampaignContentScopeInput!) {
+        updateBrevoContact(id: $id, input: $input, scope: $scope) {
+            id
+        }
+    }
+`;
+
+function BrevoTestContactsGridToolbar({ intl, scope }: { intl: IntlShape; scope: GQLEmailCampaignContentScopeInput }) {
+    const [moreActionsMenuItem, contactImportComponent] = useContactImportFromCsv({
+        scope,
+        refetchQueries: [namedOperations.Query.BrevoContactsGrid],
+    });
+
+    return (
+        <>
+            <Toolbar>
+                <ToolbarTitleItem>
+                    <FormattedMessage id="cometBrevoModule.brevoContact.title" defaultMessage="Contacts" />
+                </ToolbarTitleItem>
+                <ToolbarItem>
+                    <GridToolbarQuickFilter
+                        placeholder={intl.formatMessage({ id: "cometBrevoModule.brevoContact.searchEmail", defaultMessage: "Search email address" })}
+                    />
+                </ToolbarItem>
+                <ToolbarFillSpace />
+                <ToolbarActions>
+                    <CrudMoreActionsMenu overallItems={[moreActionsMenuItem]} />
+                    <Button startIcon={<Add />} component={StackLink} pageName="add" payload="add" variant="contained" color="primary">
+                        <FormattedMessage id="cometBrevoModule.brevoContact.newContact" defaultMessage="New contact" />
+                    </Button>
+                </ToolbarActions>
+            </Toolbar>
+            {contactImportComponent}
+        </>
+    );
+}
+
+export function BrevoTestContactsGrid({
+    scope,
+    additionalAttributesFragment,
+    additionalGridFields = [],
+}: {
+    scope: ContentScopeInterface;
+    additionalAttributesFragment?: { name: string; fragment: DocumentNode };
+    additionalGridFields?: GridColDef[];
+}): React.ReactElement {
+    const brevoTestContactsQuery = gql`
+        query BrevoTestContactsGrid($offset: Int, $limit: Int, $email: String, $scope: EmailCampaignContentScopeInput!) {
+            brevoTestContacts(offset: $offset, limit: $limit, email: $email, scope: $scope) {
+                nodes {
+                    ...BrevoContactsList
+                    ${additionalAttributesFragment ? "...".concat(additionalAttributesFragment?.name) : ""}
+                }
+                totalCount
+            }
+        }
+        ${brevoContactsFragment}
+        ${additionalAttributesFragment?.fragment ?? ""}
+    `;
+    const client = useApolloClient();
+    const intl = useIntl();
+    const dataGridProps = { ...useDataGridRemote(), ...usePersistentColumnState("BrevoContactsGrid") };
+
+    const columns: GridColDef<GQLBrevoContactsListFragment>[] = [
+        {
+            field: "createdAt",
+            headerName: intl.formatMessage({ id: "cometBrevoModule.brevoContact.subscribedAt", defaultMessage: "Subscribed At" }),
+            filterable: false,
+            sortable: false,
+            width: 150,
+            renderCell: ({ row }) => intl.formatDate(new Date(row.createdAt)),
+        },
+        {
+            field: "modifiedAt",
+            headerName: intl.formatMessage({ id: "cometBrevoModule.brevoContact.modifiedAt", defaultMessage: "Modified At" }),
+            filterable: false,
+            sortable: false,
+            width: 150,
+            renderCell: ({ row }) => intl.formatDate(new Date(row.modifiedAt)),
+        },
+        {
+            field: "email",
+            headerName: intl.formatMessage({ id: "cometBrevoModule.brevoContact.email", defaultMessage: "Email" }),
+            filterable: false,
+            sortable: false,
+            width: 150,
+            flex: 1,
+        },
+        {
+            field: "emailBlacklisted",
+            headerName: intl.formatMessage({ id: "cometBrevoModule.brevoContact.emailBlocked", defaultMessage: "Email blocked" }),
+            type: "boolean",
+            filterable: false,
+            sortable: false,
+            width: 150,
+        },
+        ...additionalGridFields,
+        {
+            field: "actions",
+            headerName: "",
+            sortable: false,
+            filterable: false,
+            type: "actions",
+            renderCell: (params) => {
+                return (
+                    <>
+                        <IconButton component={StackLink} pageName="edit" payload={params.row.id.toString()}>
+                            <Edit color="primary" />
+                        </IconButton>
+                        <RowActionsMenu>
+                            <RowActionsMenu>
+                                <RowActionsItem
+                                    onClick={async () => {
+                                        await client.mutate<GQLUpdateBrevoContactMutation, GQLUpdateBrevoContactMutationVariables>({
+                                            mutation: updateBrevoContactMutation,
+                                            variables: { id: params.row.id, input: { blocked: !params.row.emailBlacklisted }, scope },
+                                            refetchQueries: [brevoTestContactsQuery],
+                                        });
+                                    }}
+                                    icon={params.row.emailBlacklisted ? <Check /> : <Block />}
+                                >
+                                    {params.row.emailBlacklisted ? (
+                                        <FormattedMessage id="cometBrevoModule.brevoContact.actions.unblock" defaultMessage="Unblock" />
+                                    ) : (
+                                        <FormattedMessage id="cometBrevoModule.brevoContact.actions.block" defaultMessage="Block" />
+                                    )}
+                                </RowActionsItem>
+
+                                <RowActionsItem
+                                    onClick={async () => {
+                                        await client.mutate<GQLDeleteBrevoContactMutation, GQLDeleteBrevoContactMutationVariables>({
+                                            mutation: deleteBrevoContactMutation,
+                                            variables: { id: params.row.id, scope },
+                                            refetchQueries: [brevoTestContactsQuery],
+                                        });
+                                    }}
+                                    icon={<Delete />}
+                                >
+                                    <FormattedMessage {...messages.delete} />
+                                </RowActionsItem>
+                            </RowActionsMenu>
+                        </RowActionsMenu>
+                    </>
+                );
+            },
+        },
+    ];
+
+    const { data, loading, error } = useQuery<GQLBrevoTestContactsGridQuery, GQLBrevoTestContactsGridQueryVariables>(brevoTestContactsQuery, {
+        variables: {
+            offset: dataGridProps.page * dataGridProps.pageSize,
+            limit: dataGridProps.pageSize,
+            email: dataGridProps.filterModel?.quickFilterValues ? dataGridProps.filterModel?.quickFilterValues[0] : undefined,
+            scope,
+        },
+    });
+
+    const rowCount = useBufferedRowCount(data?.brevoTestContacts.totalCount);
+    if (error) throw error;
+    const rows = data?.brevoTestContacts.nodes ?? [];
+
+    return (
+        <MainContent fullHeight>
+            <DataGrid
+                {...dataGridProps}
+                disableSelectionOnClick
+                rows={rows}
+                rowCount={rowCount}
+                columns={columns}
+                loading={loading}
+                components={{
+                    Toolbar: BrevoTestContactsGridToolbar,
+                }}
+                componentsProps={{
+                    toolbar: {
+                        intl,
+                        scope,
+                    },
+                }}
+            />
+        </MainContent>
+    );
+}

--- a/packages/admin/src/brevoTestContacts/BrevoTestContactsGrid.tsx
+++ b/packages/admin/src/brevoTestContacts/BrevoTestContactsGrid.tsx
@@ -14,7 +14,7 @@ import {
     useDataGridRemote,
     usePersistentColumnState,
 } from "@comet/admin";
-import { Add, Block, Check, Delete, Edit } from "@comet/admin-icons";
+import { Add, Delete, Edit } from "@comet/admin-icons";
 import { ContentScopeInterface } from "@comet/cms-admin";
 import { Button, IconButton } from "@mui/material";
 import { DataGrid, GridColDef, GridToolbarQuickFilter } from "@mui/x-data-grid";
@@ -30,8 +30,6 @@ import {
     GQLBrevoTestContactsGridQueryVariables,
     GQLDeleteBrevoContactMutation,
     GQLDeleteBrevoContactMutationVariables,
-    GQLUpdateBrevoContactMutation,
-    GQLUpdateBrevoContactMutationVariables,
     namedOperations,
 } from "./BrevoTestContactsGrid.generated";
 
@@ -49,14 +47,6 @@ const brevoContactsFragment = gql`
 const deleteBrevoContactMutation = gql`
     mutation DeleteBrevoContact($id: Int!, $scope: EmailCampaignContentScopeInput!) {
         deleteBrevoContact(id: $id, scope: $scope)
-    }
-`;
-
-const updateBrevoContactMutation = gql`
-    mutation UpdateBrevoContact($id: Int!, $input: BrevoContactUpdateInput!, $scope: EmailCampaignContentScopeInput!) {
-        updateBrevoContact(id: $id, input: $input, scope: $scope) {
-            id
-        }
     }
 `;
 
@@ -141,14 +131,6 @@ export function BrevoTestContactsGrid({
             width: 150,
             flex: 1,
         },
-        {
-            field: "emailBlacklisted",
-            headerName: intl.formatMessage({ id: "cometBrevoModule.brevoContact.emailBlocked", defaultMessage: "Email blocked" }),
-            type: "boolean",
-            filterable: false,
-            sortable: false,
-            width: 150,
-        },
         ...additionalGridFields,
         {
             field: "actions",
@@ -164,23 +146,6 @@ export function BrevoTestContactsGrid({
                         </IconButton>
                         <RowActionsMenu>
                             <RowActionsMenu>
-                                <RowActionsItem
-                                    onClick={async () => {
-                                        await client.mutate<GQLUpdateBrevoContactMutation, GQLUpdateBrevoContactMutationVariables>({
-                                            mutation: updateBrevoContactMutation,
-                                            variables: { id: params.row.id, input: { blocked: !params.row.emailBlacklisted }, scope },
-                                            refetchQueries: [brevoTestContactsQuery],
-                                        });
-                                    }}
-                                    icon={params.row.emailBlacklisted ? <Check /> : <Block />}
-                                >
-                                    {params.row.emailBlacklisted ? (
-                                        <FormattedMessage id="cometBrevoModule.brevoContact.actions.unblock" defaultMessage="Unblock" />
-                                    ) : (
-                                        <FormattedMessage id="cometBrevoModule.brevoContact.actions.block" defaultMessage="Block" />
-                                    )}
-                                </RowActionsItem>
-
                                 <RowActionsItem
                                     onClick={async () => {
                                         await client.mutate<GQLDeleteBrevoContactMutation, GQLDeleteBrevoContactMutationVariables>({

--- a/packages/admin/src/brevoTestContacts/BrevoTestContactsGrid.tsx
+++ b/packages/admin/src/brevoTestContacts/BrevoTestContactsGrid.tsx
@@ -1,5 +1,6 @@
 import { DocumentNode, gql, useApolloClient, useQuery } from "@apollo/client";
 import {
+    Alert,
     MainContent,
     messages,
     RowActionsItem,
@@ -16,7 +17,7 @@ import {
 } from "@comet/admin";
 import { Add, Delete, Edit } from "@comet/admin-icons";
 import { ContentScopeInterface } from "@comet/cms-admin";
-import { Button, IconButton } from "@mui/material";
+import { Box, Button, IconButton } from "@mui/material";
 import { DataGrid, GridColDef, GridToolbarQuickFilter } from "@mui/x-data-grid";
 import * as React from "react";
 import { FormattedMessage, IntlShape, useIntl } from "react-intl";
@@ -181,6 +182,14 @@ export function BrevoTestContactsGrid({
 
     return (
         <MainContent fullHeight>
+            <Box sx={{ marginBottom: 4 }}>
+                <Alert severity="warning">
+                    <FormattedMessage
+                        id="cometBrevoModule.brevoTestContact.testContactAlert"
+                        defaultMessage="Contacts in this list are only added for testing purposes. Users do not get a double-opt in to confirm their subscription."
+                    />
+                </Alert>
+            </Box>
             <DataGrid
                 {...dataGridProps}
                 disableSelectionOnClick

--- a/packages/admin/src/brevoTestContacts/BrevoTestContactsGrid.tsx
+++ b/packages/admin/src/brevoTestContacts/BrevoTestContactsGrid.tsx
@@ -26,13 +26,14 @@ import { GQLEmailCampaignContentScopeInput } from "../graphql.generated";
 import { CrudMoreActionsMenu } from "../temp/CrudMoreActionsMenu";
 import {
     GQLBrevoContactsListFragment,
+    GQLBrevoTestContactsGridQuery,
+    GQLBrevoTestContactsGridQueryVariables,
     GQLDeleteBrevoContactMutation,
     GQLDeleteBrevoContactMutationVariables,
     GQLUpdateBrevoContactMutation,
     GQLUpdateBrevoContactMutationVariables,
     namedOperations,
-} from "./BrevoContactsGrid.generated";
-import { GQLBrevoTestContactsGridQuery, GQLBrevoTestContactsGridQueryVariables } from "./BrevoTestContactsGrid.generated";
+} from "./BrevoTestContactsGrid.generated";
 
 const brevoContactsFragment = gql`
     fragment BrevoContactsList on BrevoContact {
@@ -62,7 +63,7 @@ const updateBrevoContactMutation = gql`
 function BrevoTestContactsGridToolbar({ intl, scope }: { intl: IntlShape; scope: GQLEmailCampaignContentScopeInput }) {
     const [moreActionsMenuItem, contactImportComponent] = useContactImportFromCsv({
         scope,
-        refetchQueries: [namedOperations.Query.BrevoContactsGrid],
+        refetchQueries: [namedOperations.Query.BrevoTestContactsGrid],
     });
 
     return (

--- a/packages/admin/src/brevoTestContacts/BrevoTestContactsGrid.tsx
+++ b/packages/admin/src/brevoTestContacts/BrevoTestContactsGrid.tsx
@@ -27,8 +27,8 @@ import {
     GQLBrevoContactsListFragment,
     GQLBrevoTestContactsGridQuery,
     GQLBrevoTestContactsGridQueryVariables,
-    GQLDeleteBrevoContactMutation,
-    GQLDeleteBrevoContactMutationVariables,
+    GQLDeleteBrevoTestContactMutation,
+    GQLDeleteBrevoTestContactMutationVariables,
 } from "./BrevoTestContactsGrid.generated";
 
 const brevoContactsFragment = gql`
@@ -42,9 +42,9 @@ const brevoContactsFragment = gql`
     }
 `;
 
-const deleteBrevoContactMutation = gql`
-    mutation DeleteBrevoContact($id: Int!, $scope: EmailCampaignContentScopeInput!) {
-        deleteBrevoContact(id: $id, scope: $scope)
+const deleteBrevoTestContactMutation = gql`
+    mutation DeleteBrevoTestContact($id: Int!, $scope: EmailCampaignContentScopeInput!) {
+        deleteBrevoTestContact(id: $id, scope: $scope)
     }
 `;
 
@@ -142,8 +142,8 @@ export function BrevoTestContactsGrid({
                             <RowActionsMenu>
                                 <RowActionsItem
                                     onClick={async () => {
-                                        await client.mutate<GQLDeleteBrevoContactMutation, GQLDeleteBrevoContactMutationVariables>({
-                                            mutation: deleteBrevoContactMutation,
+                                        await client.mutate<GQLDeleteBrevoTestContactMutation, GQLDeleteBrevoTestContactMutationVariables>({
+                                            mutation: deleteBrevoTestContactMutation,
                                             variables: { id: params.row.id, scope },
                                             refetchQueries: [brevoTestContactsQuery],
                                         });

--- a/packages/admin/src/brevoTestContacts/BrevoTestContactsGrid.tsx
+++ b/packages/admin/src/brevoTestContacts/BrevoTestContactsGrid.tsx
@@ -22,16 +22,13 @@ import { DataGrid, GridColDef, GridToolbarQuickFilter } from "@mui/x-data-grid";
 import * as React from "react";
 import { FormattedMessage, IntlShape, useIntl } from "react-intl";
 
-import { useContactImportFromCsv } from "../common/contactImport/useContactImportFromCsv";
 import { GQLEmailCampaignContentScopeInput } from "../graphql.generated";
-import { CrudMoreActionsMenu } from "../temp/CrudMoreActionsMenu";
 import {
     GQLBrevoContactsListFragment,
     GQLBrevoTestContactsGridQuery,
     GQLBrevoTestContactsGridQueryVariables,
     GQLDeleteBrevoContactMutation,
     GQLDeleteBrevoContactMutationVariables,
-    namedOperations,
 } from "./BrevoTestContactsGrid.generated";
 
 const brevoContactsFragment = gql`
@@ -52,31 +49,27 @@ const deleteBrevoContactMutation = gql`
 `;
 
 function BrevoTestContactsGridToolbar({ intl, scope }: { intl: IntlShape; scope: GQLEmailCampaignContentScopeInput }) {
-    const [moreActionsMenuItem, contactImportComponent] = useContactImportFromCsv({
-        scope,
-        refetchQueries: [namedOperations.Query.BrevoTestContactsGrid],
-    });
-
     return (
         <>
             <Toolbar>
                 <ToolbarTitleItem>
-                    <FormattedMessage id="cometBrevoModule.brevoContact.title" defaultMessage="Contacts" />
+                    <FormattedMessage id="cometBrevoModule.brevoTestContact.title" defaultMessage="Test contacts" />
                 </ToolbarTitleItem>
                 <ToolbarItem>
                     <GridToolbarQuickFilter
-                        placeholder={intl.formatMessage({ id: "cometBrevoModule.brevoContact.searchEmail", defaultMessage: "Search email address" })}
+                        placeholder={intl.formatMessage({
+                            id: "cometBrevoModule.brevoTestContact.searchEmail",
+                            defaultMessage: "Search email address",
+                        })}
                     />
                 </ToolbarItem>
                 <ToolbarFillSpace />
                 <ToolbarActions>
-                    <CrudMoreActionsMenu overallItems={[moreActionsMenuItem]} />
                     <Button startIcon={<Add />} component={StackLink} pageName="add" payload="add" variant="contained" color="primary">
-                        <FormattedMessage id="cometBrevoModule.brevoContact.newContact" defaultMessage="New contact" />
+                        <FormattedMessage id="cometBrevoModule.brevoTestContact.newContact" defaultMessage="New test contact" />
                     </Button>
                 </ToolbarActions>
             </Toolbar>
-            {contactImportComponent}
         </>
     );
 }
@@ -110,7 +103,7 @@ export function BrevoTestContactsGrid({
     const columns: GridColDef<GQLBrevoContactsListFragment>[] = [
         {
             field: "createdAt",
-            headerName: intl.formatMessage({ id: "cometBrevoModule.brevoContact.subscribedAt", defaultMessage: "Subscribed At" }),
+            headerName: intl.formatMessage({ id: "cometBrevoModule.brevoTestContact.subscribedAt", defaultMessage: "Subscribed At" }),
             filterable: false,
             sortable: false,
             width: 150,
@@ -118,7 +111,7 @@ export function BrevoTestContactsGrid({
         },
         {
             field: "modifiedAt",
-            headerName: intl.formatMessage({ id: "cometBrevoModule.brevoContact.modifiedAt", defaultMessage: "Modified At" }),
+            headerName: intl.formatMessage({ id: "cometBrevoModule.brevoTestContact.modifiedAt", defaultMessage: "Modified At" }),
             filterable: false,
             sortable: false,
             width: 150,
@@ -126,7 +119,7 @@ export function BrevoTestContactsGrid({
         },
         {
             field: "email",
-            headerName: intl.formatMessage({ id: "cometBrevoModule.brevoContact.email", defaultMessage: "Email" }),
+            headerName: intl.formatMessage({ id: "cometBrevoModule.brevoTestContact.email", defaultMessage: "Email" }),
             filterable: false,
             sortable: false,
             width: 150,

--- a/packages/admin/src/brevoTestContacts/BrevoTestContactsPage.tsx
+++ b/packages/admin/src/brevoTestContacts/BrevoTestContactsPage.tsx
@@ -1,0 +1,78 @@
+import { Stack, StackPage, StackSwitch } from "@comet/admin";
+import { useContentScope } from "@comet/cms-admin";
+import { GridColDef } from "@mui/x-data-grid";
+import { DocumentNode } from "graphql";
+import * as React from "react";
+import { useIntl } from "react-intl";
+
+import { BrevoTestContactsGrid } from "./BrevoTestContactsGrid";
+import { BrevoTestContactForm, EditBrevoContactFormValues } from "./form/BrevoTestContactForm";
+
+interface CreateContactsPageOptions {
+    scopeParts: string[];
+    additionalAttributesFragment?: { name: string; fragment: DocumentNode };
+    additionalGridFields?: GridColDef[];
+    additionalFormFields?: React.ReactNode;
+    input2State?: (values?: EditBrevoContactFormValues) => EditBrevoContactFormValues;
+}
+
+function createBrevoTestContactsPage({
+    scopeParts,
+    additionalAttributesFragment,
+    additionalFormFields,
+    additionalGridFields,
+    input2State,
+}: CreateContactsPageOptions) {
+    function BrevoTestContactsPage(): JSX.Element {
+        const intl = useIntl();
+        const { scope: completeScope } = useContentScope();
+
+        const scope = scopeParts.reduce((acc, scopePart) => {
+            acc[scopePart] = completeScope[scopePart];
+            return acc;
+        }, {} as { [key: string]: unknown });
+
+        return (
+            <Stack topLevelTitle={intl.formatMessage({ id: "cometBrevoModule.brevoContacts.brevoContacts", defaultMessage: "Contacts" })}>
+                <StackSwitch>
+                    <StackPage name="grid">
+                        <BrevoTestContactsGrid
+                            scope={scope}
+                            additionalAttributesFragment={additionalAttributesFragment}
+                            additionalGridFields={additionalGridFields}
+                        />
+                    </StackPage>
+                    <StackPage
+                        name="edit"
+                        title={intl.formatMessage({ id: "cometBrevoModule.brevoContacts.editBrevoContact", defaultMessage: "Edit contact" })}
+                    >
+                        {(selectedId) => (
+                            <BrevoTestContactForm
+                                additionalFormFields={additionalFormFields}
+                                additionalAttributesFragment={additionalAttributesFragment}
+                                input2State={input2State}
+                                id={Number(selectedId)}
+                                scope={scope}
+                            />
+                        )}
+                    </StackPage>
+                    <StackPage
+                        name="add"
+                        title={intl.formatMessage({ id: "cometBrevoModule.brevoContacts.addBrevoContact", defaultMessage: "Add contact" })}
+                    >
+                        <BrevoTestContactForm
+                            additionalFormFields={additionalFormFields}
+                            additionalAttributesFragment={additionalAttributesFragment}
+                            input2State={input2State}
+                            scope={scope}
+                        />
+                    </StackPage>
+                </StackSwitch>
+            </Stack>
+        );
+    }
+
+    return BrevoTestContactsPage;
+}
+
+export { createBrevoTestContactsPage };

--- a/packages/admin/src/brevoTestContacts/form/BrevoTestContactForm.gql.ts
+++ b/packages/admin/src/brevoTestContacts/form/BrevoTestContactForm.gql.ts
@@ -1,14 +1,14 @@
 import { DocumentNode, gql } from "@apollo/client";
 
-export const brevoContactFormQuery = (brevoContactFormFragment: DocumentNode) => gql`
+export const brevoContactFormQuery = (brevoTestContactFormFragment: DocumentNode) => gql`
     query BrevoContactForm($id: Int!, $scope: EmailCampaignContentScopeInput!) {
         brevoContact(id: $id, scope: $scope) {
             id
             modifiedAt
-            ...BrevoContactForm
+            ...BrevoTestContactForm
         }
     }
-    ${brevoContactFormFragment}
+    ${brevoTestContactFormFragment}
 `;
 
 export const brevoContactFormCheckForChangesQuery = gql`
@@ -25,13 +25,13 @@ export const createBrevoTestContactMutation = gql`
     }
 `;
 
-export const updateBrevoContactMutation = (brevoContactFormFragment: DocumentNode) => gql`
+export const updateBrevoContactMutation = (brevoTestContactFormFragment: DocumentNode) => gql`
     mutation UpdateBrevoContact($id: Int!, $input: BrevoContactUpdateInput!, $scope: EmailCampaignContentScopeInput!) {
         updateBrevoContact(id: $id, input: $input, scope: $scope) {
             id
             modifiedAt
-            ...BrevoContactForm
+            ...BrevoTestContactForm
         }
     }
-    ${brevoContactFormFragment}
+    ${brevoTestContactFormFragment}
 `;

--- a/packages/admin/src/brevoTestContacts/form/BrevoTestContactForm.gql.ts
+++ b/packages/admin/src/brevoTestContacts/form/BrevoTestContactForm.gql.ts
@@ -1,0 +1,37 @@
+import { DocumentNode, gql } from "@apollo/client";
+
+export const brevoContactFormQuery = (brevoContactFormFragment: DocumentNode) => gql`
+    query BrevoContactForm($id: Int!, $scope: EmailCampaignContentScopeInput!) {
+        brevoContact(id: $id, scope: $scope) {
+            id
+            modifiedAt
+            ...BrevoContactForm
+        }
+    }
+    ${brevoContactFormFragment}
+`;
+
+export const brevoContactFormCheckForChangesQuery = gql`
+    query BrevoContactFormCheckForChanges($id: Int!, $scope: EmailCampaignContentScopeInput!) {
+        brevoContact(id: $id, scope: $scope) {
+            modifiedAt
+        }
+    }
+`;
+
+export const createBrevoTestContactMutation = gql`
+    mutation CreateBrevoTestContact($scope: EmailCampaignContentScopeInput!, $input: BrevoContactInput!) {
+        createBrevoTestContact(scope: $scope, input: $input)
+    }
+`;
+
+export const updateBrevoContactMutation = (brevoContactFormFragment: DocumentNode) => gql`
+    mutation UpdateBrevoContact($id: Int!, $input: BrevoContactUpdateInput!, $scope: EmailCampaignContentScopeInput!) {
+        updateBrevoContact(id: $id, input: $input, scope: $scope) {
+            id
+            modifiedAt
+            ...BrevoContactForm
+        }
+    }
+    ${brevoContactFormFragment}
+`;

--- a/packages/admin/src/brevoTestContacts/form/BrevoTestContactForm.gql.ts
+++ b/packages/admin/src/brevoTestContacts/form/BrevoTestContactForm.gql.ts
@@ -20,7 +20,7 @@ export const brevoContactFormCheckForChangesQuery = gql`
 `;
 
 export const createBrevoTestContactMutation = gql`
-    mutation CreateBrevoTestContact($scope: EmailCampaignContentScopeInput!, $input: BrevoContactInput!) {
+    mutation CreateBrevoTestContact($scope: EmailCampaignContentScopeInput!, $input: BrevoTestContactInput!) {
         createBrevoTestContact(scope: $scope, input: $input)
     }
 `;

--- a/packages/admin/src/brevoTestContacts/form/BrevoTestContactForm.tsx
+++ b/packages/admin/src/brevoTestContacts/form/BrevoTestContactForm.tsx
@@ -1,0 +1,211 @@
+import { DocumentNode, gql, useApolloClient, useQuery } from "@apollo/client";
+import {
+    Alert,
+    FinalForm,
+    FinalFormSaveSplitButton,
+    FinalFormSubmitEvent,
+    FormSection,
+    Loading,
+    MainContent,
+    TextField,
+    Toolbar,
+    ToolbarActions,
+    ToolbarFillSpace,
+    ToolbarItem,
+    ToolbarTitleItem,
+    useFormApiRef,
+    useStackApi,
+} from "@comet/admin";
+import { ArrowLeft } from "@comet/admin-icons";
+import { ContentScopeInterface, EditPageLayout, resolveHasSaveConflict, useFormSaveConflict } from "@comet/cms-admin";
+import { Card, IconButton } from "@mui/material";
+import { Box } from "@mui/system";
+import { FormApi } from "final-form";
+import React from "react";
+import { FormattedMessage } from "react-intl";
+
+import {
+    brevoContactFormCheckForChangesQuery,
+    brevoContactFormQuery,
+    createBrevoTestContactMutation,
+    updateBrevoContactMutation,
+} from "./BrevoTestContactForm.gql";
+import {
+    GQLBrevoContactFormCheckForChangesQuery,
+    GQLBrevoContactFormCheckForChangesQueryVariables,
+    GQLBrevoContactFormQuery,
+    GQLBrevoContactFormQueryVariables,
+    GQLCreateBrevoTestContactMutation,
+    GQLCreateBrevoTestContactMutationVariables,
+    GQLUpdateBrevoContactMutation,
+    GQLUpdateBrevoContactMutationVariables,
+} from "./BrevoTestContactForm.gql.generated";
+
+export type EditBrevoContactFormValues = {
+    email: string;
+    redirectionUrl: string;
+    [key: string]: unknown;
+};
+
+interface FormProps {
+    id?: number;
+    scope: ContentScopeInterface;
+    additionalFormFields?: React.ReactNode;
+    additionalAttributesFragment?: { name: string; fragment: DocumentNode };
+    input2State?: (values?: EditBrevoContactFormValues) => EditBrevoContactFormValues;
+}
+
+export function BrevoTestContactForm({ id, scope, input2State, additionalFormFields, additionalAttributesFragment }: FormProps): React.ReactElement {
+    const stackApi = useStackApi();
+    const client = useApolloClient();
+    const mode = id ? "edit" : "add";
+    const formApiRef = useFormApiRef<EditBrevoContactFormValues>();
+
+    const brevoContactFormFragment = gql`
+        fragment BrevoContactForm on BrevoContact {
+            email
+            createdAt
+            emailBlacklisted
+            smsBlacklisted
+            ${additionalAttributesFragment ? "...".concat(additionalAttributesFragment?.name) : ""}
+        }
+        ${additionalAttributesFragment?.fragment ?? ""}
+`;
+    const { data, error, loading, refetch } = useQuery<GQLBrevoContactFormQuery, GQLBrevoContactFormQueryVariables>(
+        brevoContactFormQuery(brevoContactFormFragment),
+        id ? { variables: { id, scope } } : { skip: true },
+    );
+
+    const initialValues = React.useMemo<Partial<EditBrevoContactFormValues>>(() => {
+        let additionalInitialValues = {};
+
+        if (input2State) {
+            additionalInitialValues = input2State({ email: "", redirectionUrl: "", ...data?.brevoContact });
+        }
+        return data?.brevoContact
+            ? {
+                  email: data.brevoContact.email,
+                  ...additionalInitialValues,
+              }
+            : additionalInitialValues;
+    }, [data?.brevoContact, input2State]);
+
+    const saveConflict = useFormSaveConflict({
+        checkConflict: async () => {
+            if (!id) {
+                return false;
+            }
+            const { data: updatedData } = await client.query<
+                GQLBrevoContactFormCheckForChangesQuery,
+                GQLBrevoContactFormCheckForChangesQueryVariables
+            >({
+                query: brevoContactFormCheckForChangesQuery,
+                variables: { id, scope },
+                fetchPolicy: "no-cache",
+            });
+
+            return resolveHasSaveConflict(data?.brevoContact?.modifiedAt, updatedData.brevoContact.modifiedAt);
+        },
+        formApiRef,
+        loadLatestVersion: async () => {
+            await refetch();
+        },
+    });
+
+    const handleSubmit = async (state: EditBrevoContactFormValues, form: FormApi<EditBrevoContactFormValues>, event: FinalFormSubmitEvent) => {
+        if (await saveConflict.checkForConflicts()) {
+            throw new Error("Conflicts detected");
+        }
+
+        const output = {
+            ...state,
+            blocked: false,
+        };
+
+        if (mode === "edit") {
+            if (!id) {
+                throw new Error("Missing id in edit mode");
+            }
+            const { email, redirectionUrl, ...rest } = output;
+            await client.mutate<GQLUpdateBrevoContactMutation, GQLUpdateBrevoContactMutationVariables>({
+                mutation: updateBrevoContactMutation(brevoContactFormFragment),
+                variables: { id, input: rest, scope },
+            });
+        } else {
+            const { data: mutationResponse } = await client.mutate<GQLCreateBrevoTestContactMutation, GQLCreateBrevoTestContactMutationVariables>({
+                mutation: createBrevoTestContactMutation,
+                variables: { scope, input: output },
+            });
+            if (!event.navigatingBack) {
+                const response = mutationResponse?.createBrevoTestContact;
+
+                if (response === "SUCCESSFUL") {
+                    setTimeout(() => {
+                        stackApi?.goBack();
+                    });
+                } else if (response === "ERROR_CONTAINED_IN_ECG_RTR_LIST") {
+                    throw new Error("Contact contained in ECG RTR list, cannot create contact");
+                } else {
+                    throw new Error("Error creating contact");
+                }
+            }
+        }
+    };
+
+    if (error) throw error;
+
+    if (loading) {
+        return <Loading behavior="fillPageHeight" />;
+    }
+
+    return (
+        <FinalForm<EditBrevoContactFormValues> apiRef={formApiRef} onSubmit={handleSubmit} mode={mode} initialValues={initialValues}>
+            {({ values }) => (
+                <EditPageLayout>
+                    {saveConflict.dialogs}
+                    <Toolbar>
+                        <ToolbarItem>
+                            <IconButton onClick={stackApi?.goBack}>
+                                <ArrowLeft />
+                            </IconButton>
+                        </ToolbarItem>
+                        <ToolbarTitleItem>
+                            <FormattedMessage id="cometBrevoModule.brevoContacts.brevoContact" defaultMessage="Contact" />
+                        </ToolbarTitleItem>
+                        <ToolbarFillSpace />
+                        <ToolbarActions>
+                            <FinalFormSaveSplitButton hasConflict={saveConflict.hasConflict} />
+                        </ToolbarActions>
+                    </Toolbar>
+                    <MainContent>
+                        {mode === "edit" && (
+                            <Box sx={{ marginBottom: 4 }}>
+                                <Alert severity="warning">
+                                    <FormattedMessage
+                                        id="cometBrevoModule.brevoContact.contactEditAlert"
+                                        defaultMessage="Editing a contact will affect all scopes and the target groups within those scopes."
+                                    />
+                                </Alert>
+                            </Box>
+                        )}
+                        <TextField
+                            required
+                            fullWidth
+                            name="email"
+                            label={<FormattedMessage id="cometBrevoModule.brevoContact.email" defaultMessage="Email" />}
+                            disabled={mode === "edit"}
+                        />
+
+                        {additionalFormFields && (
+                            <Card sx={{ padding: 4 }}>
+                                <FormSection title={<FormattedMessage id="cometBrevoModule.brevoContact.attributes" defaultMessage="Attributes" />}>
+                                    {additionalFormFields}
+                                </FormSection>
+                            </Card>
+                        )}
+                    </MainContent>
+                </EditPageLayout>
+            )}
+        </FinalForm>
+    );
+}

--- a/packages/admin/src/brevoTestContacts/form/BrevoTestContactForm.tsx
+++ b/packages/admin/src/brevoTestContacts/form/BrevoTestContactForm.tsx
@@ -42,8 +42,11 @@ import {
 } from "./BrevoTestContactForm.gql.generated";
 
 export type EditBrevoContactFormValues = {
-    email: string;
     [key: string]: unknown;
+};
+
+type BaseBrevoContactFormValues = EditBrevoContactFormValues & {
+    email: string;
 };
 
 interface FormProps {
@@ -58,10 +61,10 @@ export function BrevoTestContactForm({ id, scope, input2State, additionalFormFie
     const stackApi = useStackApi();
     const client = useApolloClient();
     const mode = id ? "edit" : "add";
-    const formApiRef = useFormApiRef<EditBrevoContactFormValues>();
+    const formApiRef = useFormApiRef<BaseBrevoContactFormValues>();
 
-    const brevoContactFormFragment = gql`
-        fragment BrevoContactForm on BrevoContact {
+    const brevoTestContactFormFragment = gql`
+        fragment BrevoTestContactForm on BrevoContact {
             email
             createdAt
             emailBlacklisted
@@ -71,7 +74,7 @@ export function BrevoTestContactForm({ id, scope, input2State, additionalFormFie
         ${additionalAttributesFragment?.fragment ?? ""}
 `;
     const { data, error, loading, refetch } = useQuery<GQLBrevoContactFormQuery, GQLBrevoContactFormQueryVariables>(
-        brevoContactFormQuery(brevoContactFormFragment),
+        brevoContactFormQuery(brevoTestContactFormFragment),
         id ? { variables: { id, scope } } : { skip: true },
     );
 
@@ -79,7 +82,10 @@ export function BrevoTestContactForm({ id, scope, input2State, additionalFormFie
         let additionalInitialValues = {};
 
         if (input2State) {
-            additionalInitialValues = input2State({ email: "", ...data?.brevoContact });
+            additionalInitialValues = input2State({
+                email: "",
+                ...data?.brevoContact,
+            });
         }
         return data?.brevoContact
             ? {
@@ -111,7 +117,7 @@ export function BrevoTestContactForm({ id, scope, input2State, additionalFormFie
         },
     });
 
-    const handleSubmit = async (state: EditBrevoContactFormValues, form: FormApi<EditBrevoContactFormValues>, event: FinalFormSubmitEvent) => {
+    const handleSubmit = async (state: BaseBrevoContactFormValues, form: FormApi<BaseBrevoContactFormValues>, event: FinalFormSubmitEvent) => {
         if (await saveConflict.checkForConflicts()) {
             throw new Error("Conflicts detected");
         }
@@ -127,7 +133,7 @@ export function BrevoTestContactForm({ id, scope, input2State, additionalFormFie
             }
             const { email, ...rest } = output;
             await client.mutate<GQLUpdateBrevoContactMutation, GQLUpdateBrevoContactMutationVariables>({
-                mutation: updateBrevoContactMutation(brevoContactFormFragment),
+                mutation: updateBrevoContactMutation(brevoTestContactFormFragment),
                 variables: { id, input: rest, scope },
             });
         } else {
@@ -158,7 +164,7 @@ export function BrevoTestContactForm({ id, scope, input2State, additionalFormFie
     }
 
     return (
-        <FinalForm<EditBrevoContactFormValues> apiRef={formApiRef} onSubmit={handleSubmit} mode={mode} initialValues={initialValues}>
+        <FinalForm<BaseBrevoContactFormValues> apiRef={formApiRef} onSubmit={handleSubmit} mode={mode} initialValues={initialValues}>
             {({ values }) => (
                 <EditPageLayout>
                     {saveConflict.dialogs}

--- a/packages/admin/src/brevoTestContacts/form/BrevoTestContactForm.tsx
+++ b/packages/admin/src/brevoTestContacts/form/BrevoTestContactForm.tsx
@@ -78,21 +78,19 @@ export function BrevoTestContactForm({ id, scope, input2State, additionalFormFie
         id ? { variables: { id, scope } } : { skip: true },
     );
 
-    const initialValues = React.useMemo<Partial<EditBrevoContactFormValues>>(() => {
-        let additionalInitialValues = {};
+    const initialValues = React.useMemo<Partial<BaseBrevoContactFormValues>>(() => {
+        let baseInitialValues = {
+            email: "",
+        };
 
         if (input2State) {
-            additionalInitialValues = input2State({
-                email: "",
-                ...data?.brevoContact,
-            });
+            baseInitialValues = {
+                ...baseInitialValues,
+                ...input2State(data?.brevoContact),
+            };
         }
-        return data?.brevoContact
-            ? {
-                  email: data.brevoContact.email,
-                  ...additionalInitialValues,
-              }
-            : additionalInitialValues;
+
+        return data?.brevoContact?.email ? { ...baseInitialValues, email: data.brevoContact.email } : baseInitialValues;
     }, [data?.brevoContact, input2State]);
 
     const saveConflict = useFormSaveConflict({

--- a/packages/admin/src/brevoTestContacts/form/BrevoTestContactForm.tsx
+++ b/packages/admin/src/brevoTestContacts/form/BrevoTestContactForm.tsx
@@ -170,7 +170,7 @@ export function BrevoTestContactForm({ id, scope, input2State, additionalFormFie
                             </IconButton>
                         </ToolbarItem>
                         <ToolbarTitleItem>
-                            <FormattedMessage id="cometBrevoModule.brevoContacts.brevoContact" defaultMessage="Contact" />
+                            <FormattedMessage id="cometBrevoModule.brevoTestContacts.brevoTestContact" defaultMessage="Test contact" />
                         </ToolbarTitleItem>
                         <ToolbarFillSpace />
                         <ToolbarActions>
@@ -192,13 +192,15 @@ export function BrevoTestContactForm({ id, scope, input2State, additionalFormFie
                             required
                             fullWidth
                             name="email"
-                            label={<FormattedMessage id="cometBrevoModule.brevoContact.email" defaultMessage="Email" />}
+                            label={<FormattedMessage id="cometBrevoModule.brevoTestContact.email" defaultMessage="Email" />}
                             disabled={mode === "edit"}
                         />
 
                         {additionalFormFields && (
                             <Card sx={{ padding: 4 }}>
-                                <FormSection title={<FormattedMessage id="cometBrevoModule.brevoContact.attributes" defaultMessage="Attributes" />}>
+                                <FormSection
+                                    title={<FormattedMessage id="cometBrevoModule.brevoTestContact.attributes" defaultMessage="Attributes" />}
+                                >
                                     {additionalFormFields}
                                 </FormSection>
                             </Card>

--- a/packages/admin/src/brevoTestContacts/form/BrevoTestContactForm.tsx
+++ b/packages/admin/src/brevoTestContacts/form/BrevoTestContactForm.tsx
@@ -45,7 +45,7 @@ export type EditBrevoContactFormValues = {
     [key: string]: unknown;
 };
 
-type BaseBrevoContactFormValues = EditBrevoContactFormValues & {
+type EditBrevoContactFormValuesWithAttributes = EditBrevoContactFormValues & {
     email: string;
 };
 
@@ -61,7 +61,7 @@ export function BrevoTestContactForm({ id, scope, input2State, additionalFormFie
     const stackApi = useStackApi();
     const client = useApolloClient();
     const mode = id ? "edit" : "add";
-    const formApiRef = useFormApiRef<BaseBrevoContactFormValues>();
+    const formApiRef = useFormApiRef<EditBrevoContactFormValuesWithAttributes>();
 
     const brevoTestContactFormFragment = gql`
         fragment BrevoTestContactForm on BrevoContact {
@@ -78,7 +78,7 @@ export function BrevoTestContactForm({ id, scope, input2State, additionalFormFie
         id ? { variables: { id, scope } } : { skip: true },
     );
 
-    const initialValues = React.useMemo<Partial<BaseBrevoContactFormValues>>(() => {
+    const initialValues = React.useMemo<Partial<EditBrevoContactFormValuesWithAttributes>>(() => {
         let baseInitialValues = {
             email: "",
         };
@@ -115,7 +115,11 @@ export function BrevoTestContactForm({ id, scope, input2State, additionalFormFie
         },
     });
 
-    const handleSubmit = async (state: BaseBrevoContactFormValues, form: FormApi<BaseBrevoContactFormValues>, event: FinalFormSubmitEvent) => {
+    const handleSubmit = async (
+        state: EditBrevoContactFormValuesWithAttributes,
+        form: FormApi<EditBrevoContactFormValuesWithAttributes>,
+        event: FinalFormSubmitEvent,
+    ) => {
         if (await saveConflict.checkForConflicts()) {
             throw new Error("Conflicts detected");
         }
@@ -162,7 +166,7 @@ export function BrevoTestContactForm({ id, scope, input2State, additionalFormFie
     }
 
     return (
-        <FinalForm<BaseBrevoContactFormValues> apiRef={formApiRef} onSubmit={handleSubmit} mode={mode} initialValues={initialValues}>
+        <FinalForm<EditBrevoContactFormValuesWithAttributes> apiRef={formApiRef} onSubmit={handleSubmit} mode={mode} initialValues={initialValues}>
             {({ values }) => (
                 <EditPageLayout>
                     {saveConflict.dialogs}

--- a/packages/admin/src/brevoTestContacts/form/BrevoTestContactForm.tsx
+++ b/packages/admin/src/brevoTestContacts/form/BrevoTestContactForm.tsx
@@ -43,7 +43,6 @@ import {
 
 export type EditBrevoContactFormValues = {
     email: string;
-    redirectionUrl: string;
     [key: string]: unknown;
 };
 
@@ -80,7 +79,7 @@ export function BrevoTestContactForm({ id, scope, input2State, additionalFormFie
         let additionalInitialValues = {};
 
         if (input2State) {
-            additionalInitialValues = input2State({ email: "", redirectionUrl: "", ...data?.brevoContact });
+            additionalInitialValues = input2State({ email: "", ...data?.brevoContact });
         }
         return data?.brevoContact
             ? {
@@ -126,7 +125,7 @@ export function BrevoTestContactForm({ id, scope, input2State, additionalFormFie
             if (!id) {
                 throw new Error("Missing id in edit mode");
             }
-            const { email, redirectionUrl, ...rest } = output;
+            const { email, ...rest } = output;
             await client.mutate<GQLUpdateBrevoContactMutation, GQLUpdateBrevoContactMutationVariables>({
                 mutation: updateBrevoContactMutation(brevoContactFormFragment),
                 variables: { id, input: rest, scope },

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -1,5 +1,6 @@
 export { createBrevoContactsPage } from "./brevoContacts/BrevoContactsPage";
 export { EditBrevoContactFormValues } from "./brevoContacts/form/BrevoContactForm";
+export { createBrevoTestContactsPage } from "./brevoTestContacts/BrevoTestContactsPage";
 export { BrevoConfig, BrevoConfigProvider, useBrevoConfig } from "./common/BrevoConfigProvider";
 export { createEmailCampaignsPage } from "./emailCampaigns/EmailCampaignsPage";
 export { EditTargetGroupFinalFormValues } from "./targetGroups/TargetGroupForm";

--- a/packages/admin/src/targetGroups/TargetGroupsGrid.tsx
+++ b/packages/admin/src/targetGroups/TargetGroupsGrid.tsx
@@ -277,7 +277,7 @@ export function TargetGroupsGrid({
     });
     const rowCount = useBufferedRowCount(data?.targetGroups.totalCount);
     if (error) throw error;
-    const rows = data?.targetGroups.nodes ?? [];
+    const rows = (data?.targetGroups.nodes ?? []).filter((node) => node.title !== "Test list for current scope");
 
     return (
         <MainContent fullHeight>

--- a/packages/admin/src/targetGroups/TargetGroupsGrid.tsx
+++ b/packages/admin/src/targetGroups/TargetGroupsGrid.tsx
@@ -264,12 +264,12 @@ export function TargetGroupsGrid({
         },
     ];
 
-    const { filter: gqlFilter, search: gqlSearch } = muiGridFilterToGql(columns, dataGridProps.filterModel);
+    const { search: gqlSearch } = muiGridFilterToGql(columns, dataGridProps.filterModel);
 
     const { data, loading, error } = useQuery<GQLTargetGroupsGridQuery, GQLTargetGroupsGridQueryVariables>(targetGroupsQuery, {
         variables: {
             scope,
-            filter: gqlFilter,
+            filter: { isTestList: { equal: false || null } },
             search: gqlSearch,
             offset: dataGridProps.page * dataGridProps.pageSize,
             limit: dataGridProps.pageSize,

--- a/packages/admin/src/targetGroups/TargetGroupsGrid.tsx
+++ b/packages/admin/src/targetGroups/TargetGroupsGrid.tsx
@@ -263,11 +263,12 @@ export function TargetGroupsGrid({
         },
     ];
 
-    const { search: gqlSearch } = muiGridFilterToGql(columns, dataGridProps.filterModel);
+    const { filter: gqlFilter, search: gqlSearch } = muiGridFilterToGql(columns, dataGridProps.filterModel);
 
     const { data, loading, error } = useQuery<GQLTargetGroupsGridQuery, GQLTargetGroupsGridQueryVariables>(targetGroupsQuery, {
         variables: {
             scope,
+            filter: gqlFilter,
             search: gqlSearch,
             offset: dataGridProps.page * dataGridProps.pageSize,
             limit: dataGridProps.pageSize,

--- a/packages/admin/src/targetGroups/TargetGroupsGrid.tsx
+++ b/packages/admin/src/targetGroups/TargetGroupsGrid.tsx
@@ -50,6 +50,7 @@ const targetGroupsFragment = gql`
         totalSubscribers
         totalContactsBlocked
         isMainList
+        isTestList
     }
 `;
 
@@ -277,7 +278,7 @@ export function TargetGroupsGrid({
     });
     const rowCount = useBufferedRowCount(data?.targetGroups.totalCount);
     if (error) throw error;
-    const rows = (data?.targetGroups.nodes ?? []).filter((node) => node.title !== "Test list for current scope");
+    const rows = data?.targetGroups.nodes ?? [];
 
     return (
         <MainContent fullHeight>

--- a/packages/admin/src/targetGroups/TargetGroupsGrid.tsx
+++ b/packages/admin/src/targetGroups/TargetGroupsGrid.tsx
@@ -269,7 +269,7 @@ export function TargetGroupsGrid({
     const { data, loading, error } = useQuery<GQLTargetGroupsGridQuery, GQLTargetGroupsGridQueryVariables>(targetGroupsQuery, {
         variables: {
             scope,
-            filter: { isTestList: { equal: false || null } },
+            filter: { isTestList: { equal: null } },
             search: gqlSearch,
             offset: dataGridProps.page * dataGridProps.pageSize,
             limit: dataGridProps.pageSize,

--- a/packages/admin/src/targetGroups/TargetGroupsGrid.tsx
+++ b/packages/admin/src/targetGroups/TargetGroupsGrid.tsx
@@ -50,7 +50,6 @@ const targetGroupsFragment = gql`
         totalSubscribers
         totalContactsBlocked
         isMainList
-        isTestList
     }
 `;
 
@@ -269,7 +268,6 @@ export function TargetGroupsGrid({
     const { data, loading, error } = useQuery<GQLTargetGroupsGridQuery, GQLTargetGroupsGridQueryVariables>(targetGroupsQuery, {
         variables: {
             scope,
-            filter: { isTestList: { equal: false } },
             search: gqlSearch,
             offset: dataGridProps.page * dataGridProps.pageSize,
             limit: dataGridProps.pageSize,

--- a/packages/admin/src/targetGroups/TargetGroupsGrid.tsx
+++ b/packages/admin/src/targetGroups/TargetGroupsGrid.tsx
@@ -269,7 +269,7 @@ export function TargetGroupsGrid({
     const { data, loading, error } = useQuery<GQLTargetGroupsGridQuery, GQLTargetGroupsGridQueryVariables>(targetGroupsQuery, {
         variables: {
             scope,
-            filter: { isTestList: { equal: null } },
+            filter: { isTestList: { equal: false } },
             search: gqlSearch,
             offset: dataGridProps.page * dataGridProps.pageSize,
             limit: dataGridProps.pageSize,

--- a/packages/api/generate-schema.ts
+++ b/packages/api/generate-schema.ts
@@ -9,6 +9,7 @@ import { printSchema } from "graphql";
 import { createBrevoContactResolver } from "./src/brevo-contact/brevo-contact.resolver";
 import { BrevoContactFactory } from "./src/brevo-contact/dto/brevo-contact.factory";
 import { BrevoContactInputFactory } from "./src/brevo-contact/dto/brevo-contact-input.factory";
+import { BrevoTestContactInputFactory } from "./src/brevo-contact/dto/brevo-test-contact-input.factory";
 import { SubscribeInputFactory } from "./src/brevo-contact/dto/subscribe-input.factory";
 import { EmailCampaignInputFactory } from "./src/email-campaign/dto/email-campaign-input.factory";
 import { createEmailCampaignsResolver } from "./src/email-campaign/email-campaign.resolver";
@@ -61,6 +62,8 @@ async function generateSchema(): Promise<void> {
 
     const BrevoContact = BrevoContactFactory.create({});
     const [BrevoContactInput, BrevoContactUpdateInput] = BrevoContactInputFactory.create({ Scope: EmailCampaignScope });
+    const [BrevoTestContactInput, BrevoTestContactUpdateInput] = BrevoTestContactInputFactory.create({ Scope: EmailCampaignScope });
+
     const BrevoContactSubscribeInput = SubscribeInputFactory.create({ Scope: EmailCampaignScope });
     const BrevoContactResolver = createBrevoContactResolver({
         BrevoContact,
@@ -68,6 +71,8 @@ async function generateSchema(): Promise<void> {
         Scope: EmailCampaignScope,
         BrevoContactInput,
         BrevoContactUpdateInput,
+        BrevoTestContactInput,
+        BrevoTestContactUpdateInput,
     });
 
     const TargetGroup = TargetGroupEntityFactory.create({ Scope: EmailCampaignScope });

--- a/packages/api/schema.gql
+++ b/packages/api/schema.gql
@@ -110,6 +110,7 @@ type TargetGroup implements DocumentInterface {
   createdAt: DateTime!
   title: String!
   isMainList: Boolean!
+  isTestList: Boolean
   brevoId: Int!
   totalSubscribers: Int!
   totalContactsBlocked: Int!

--- a/packages/api/schema.gql
+++ b/packages/api/schema.gql
@@ -167,6 +167,7 @@ input EmailCampaignContentScopeInput {
 type Query {
   brevoContact(id: Int!, scope: EmailCampaignContentScopeInput!): BrevoContact!
   brevoContacts(targetGroupId: ID, email: String, scope: EmailCampaignContentScopeInput!, offset: Int! = 0, limit: Int! = 25): PaginatedBrevoContacts!
+  brevoTestContacts(targetGroupId: ID, email: String, scope: EmailCampaignContentScopeInput!, offset: Int! = 0, limit: Int! = 25): PaginatedBrevoContacts!
   manuallyAssignedBrevoContacts(offset: Int! = 0, limit: Int! = 25, targetGroupId: ID!, email: String): PaginatedBrevoContacts!
   targetGroup(id: ID!): TargetGroup!
   targetGroups(scope: EmailCampaignContentScopeInput!, search: String, filter: TargetGroupFilter, sort: [TargetGroupSort!], offset: Int! = 0, limit: Int! = 25): PaginatedTargetGroups!
@@ -242,6 +243,7 @@ enum EmailCampaignSortField {
 type Mutation {
   updateBrevoContact(id: Int!, scope: EmailCampaignContentScopeInput!, input: BrevoContactUpdateInput!): BrevoContact!
   createBrevoContact(scope: EmailCampaignContentScopeInput!, input: BrevoContactInput!): SubscribeResponse!
+  createBrevoTestContact(scope: EmailCampaignContentScopeInput!, input: BrevoContactInput!): SubscribeResponse!
   deleteBrevoContact(id: Int!, scope: EmailCampaignContentScopeInput!): Boolean!
   subscribeBrevoContact(input: SubscribeInput!, scope: EmailCampaignContentScopeInput!): SubscribeResponse!
   createTargetGroup(scope: EmailCampaignContentScopeInput!, input: TargetGroupInput!): TargetGroup!

--- a/packages/api/schema.gql
+++ b/packages/api/schema.gql
@@ -249,7 +249,7 @@ enum EmailCampaignSortField {
 type Mutation {
   updateBrevoContact(id: Int!, scope: EmailCampaignContentScopeInput!, input: BrevoContactUpdateInput!): BrevoContact!
   createBrevoContact(scope: EmailCampaignContentScopeInput!, input: BrevoContactInput!): SubscribeResponse!
-  createBrevoTestContact(scope: EmailCampaignContentScopeInput!, input: BrevoContactInput!): SubscribeResponse!
+  createBrevoTestContact(scope: EmailCampaignContentScopeInput!, input: BrevoTestContactInput!): SubscribeResponse!
   deleteBrevoContact(id: Int!, scope: EmailCampaignContentScopeInput!): Boolean!
   deleteBrevoTestContact(id: Int!, scope: EmailCampaignContentScopeInput!): Boolean!
   subscribeBrevoContact(input: SubscribeInput!, scope: EmailCampaignContentScopeInput!): SubscribeResponse!
@@ -279,6 +279,11 @@ input BrevoContactInput {
   email: String!
   blocked: Boolean!
   redirectionUrl: String!
+}
+
+input BrevoTestContactInput {
+  email: String!
+  blocked: Boolean!
 }
 
 input SubscribeInput {

--- a/packages/api/schema.gql
+++ b/packages/api/schema.gql
@@ -181,6 +181,7 @@ input TargetGroupFilter {
   createdAt: DateFilter
   updatedAt: DateFilter
   title: StringFilter
+  isTestList: BooleanFilter
   and: [TargetGroupFilter!]
   or: [TargetGroupFilter!]
 }
@@ -200,6 +201,10 @@ input StringFilter {
   endsWith: String
   equal: String
   notEqual: String
+}
+
+input BooleanFilter {
+  equal: Boolean
 }
 
 input TargetGroupSort {

--- a/packages/api/schema.gql
+++ b/packages/api/schema.gql
@@ -251,6 +251,7 @@ type Mutation {
   createBrevoContact(scope: EmailCampaignContentScopeInput!, input: BrevoContactInput!): SubscribeResponse!
   createBrevoTestContact(scope: EmailCampaignContentScopeInput!, input: BrevoContactInput!): SubscribeResponse!
   deleteBrevoContact(id: Int!, scope: EmailCampaignContentScopeInput!): Boolean!
+  deleteBrevoTestContact(id: Int!, scope: EmailCampaignContentScopeInput!): Boolean!
   subscribeBrevoContact(input: SubscribeInput!, scope: EmailCampaignContentScopeInput!): SubscribeResponse!
   createTargetGroup(scope: EmailCampaignContentScopeInput!, input: TargetGroupInput!): TargetGroup!
   addBrevoContactsToTargetGroup(id: ID!, input: AddBrevoContactsInput!): Boolean!

--- a/packages/api/src/brevo-api/brevo-api-contact.service.ts
+++ b/packages/api/src/brevo-api/brevo-api-contact.service.ts
@@ -54,6 +54,21 @@ export class BrevoApiContactsService {
         return response.statusCode === 204 || response.statusCode === 201;
     }
 
+    public async createTestContact(
+        { email, attributes }: Brevo.CreateContact,
+        brevoIds: number[],
+        scope: EmailCampaignScopeInterface,
+    ): Promise<boolean> {
+        const contact = {
+            email,
+            listIds: brevoIds,
+            attributes,
+        };
+        const { response } = await this.getContactsApi(scope).createContact(contact);
+
+        return response.statusCode === 204 || response.statusCode === 201;
+    }
+
     public async updateContact(
         id: number,
         {

--- a/packages/api/src/brevo-contact/brevo-contact.module.ts
+++ b/packages/api/src/brevo-contact/brevo-contact.module.ts
@@ -13,6 +13,7 @@ import { createBrevoContactResolver } from "./brevo-contact.resolver";
 import { BrevoContactsService } from "./brevo-contacts.service";
 import { BrevoContactFactory } from "./dto/brevo-contact.factory";
 import { BrevoContactInputFactory } from "./dto/brevo-contact-input.factory";
+import { BrevoTestContactInputFactory } from "./dto/brevo-test-contact-input.factory";
 import { SubscribeInputFactory } from "./dto/subscribe-input.factory";
 import { EcgRtrListService } from "./ecg-rtr-list/ecg-rtr-list.service";
 import { IsValidRedirectURLConstraint } from "./validator/redirect-url.validator";
@@ -29,12 +30,15 @@ export class BrevoContactModule {
         const BrevoContact = BrevoContactFactory.create({ BrevoContactAttributes });
         const BrevoContactSubscribeInput = SubscribeInputFactory.create({ BrevoContactAttributes, Scope });
         const [BrevoContactInput, BrevoContactUpdateInput] = BrevoContactInputFactory.create({ BrevoContactAttributes, Scope });
+        const [BrevoTestContactInput] = BrevoTestContactInputFactory.create({ BrevoContactAttributes, Scope });
+
         const BrevoContactResolver = createBrevoContactResolver({
             BrevoContact,
             BrevoContactSubscribeInput,
             Scope,
             BrevoContactInput,
             BrevoContactUpdateInput,
+            BrevoTestContactInput,
         });
 
         const BrevoContactImportConsole = createBrevoContactImportConsole({ Scope });

--- a/packages/api/src/brevo-contact/brevo-contact.resolver.ts
+++ b/packages/api/src/brevo-contact/brevo-contact.resolver.ts
@@ -96,22 +96,12 @@ export function createBrevoContactResolver({
         }
 
         @Query(() => PaginatedBrevoContacts)
-        async brevoTestContacts(@Args() { offset, limit, email, targetGroupId, scope }: BrevoContactsArgs): Promise<PaginatedBrevoContacts> {
+        async brevoTestContacts(@Args() { offset, limit, email, scope }: BrevoContactsArgs): Promise<PaginatedBrevoContacts> {
             const where: FilterQuery<TargetGroupInterface> = { scope, isMainList: false, isTestList: true };
-
-            if (targetGroupId) {
-                where.id = targetGroupId;
-                where.isMainList = false;
-                where.isTestList = true;
-            }
 
             let targetGroup = await this.targetGroupRepository.findOne(where);
 
             if (!targetGroup) {
-                if (targetGroupId) {
-                    return new PaginatedBrevoContacts([], 0, { offset, limit });
-                }
-
                 // when there is no test target group for the scope, create one
                 targetGroup = await this.targetGroupService.createIfNotExistTestTargetGroupForScope(scope);
             }

--- a/packages/api/src/brevo-contact/brevo-contact.resolver.ts
+++ b/packages/api/src/brevo-contact/brevo-contact.resolver.ts
@@ -94,12 +94,12 @@ export function createBrevoContactResolver({
 
         @Query(() => PaginatedBrevoContacts)
         async brevoTestContacts(@Args() { offset, limit, email, targetGroupId, scope }: BrevoContactsArgs): Promise<PaginatedBrevoContacts> {
-            const where: FilterQuery<TargetGroupInterface> = { scope, isMainList: false };
+            const where: FilterQuery<TargetGroupInterface> = { scope, isMainList: false, isTestList: true };
 
             if (targetGroupId) {
                 where.id = targetGroupId;
                 where.isMainList = false;
-                where.title = "Test list for current scope";
+                where.isTestList = true;
             }
 
             let targetGroup = await this.targetGroupRepository.findOne(where);

--- a/packages/api/src/brevo-contact/brevo-contact.resolver.ts
+++ b/packages/api/src/brevo-contact/brevo-contact.resolver.ts
@@ -227,7 +227,7 @@ export function createBrevoContactResolver({
         }
 
         @Mutation(() => SubscribeResponse)
-        @RequiredPermission(["brevo-newsletter"], { skipScopeCheck: true })
+        @RequiredPermission(["brevo-newsletter-test-contacts"], { skipScopeCheck: true })
         async createBrevoTestContact(
             @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope)) scope: typeof Scope,
             @Args("input", { type: () => BrevoTestContactInput })

--- a/packages/api/src/brevo-contact/brevo-contact.resolver.ts
+++ b/packages/api/src/brevo-contact/brevo-contact.resolver.ts
@@ -262,6 +262,8 @@ export function createBrevoContactResolver({
             @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope)) scope: typeof Scope,
         ): Promise<boolean> {
             const contact = await this.brevoContactsApiService.findContact(id, scope);
+            if (!contact) return false;
+
             const where: FilterQuery<TargetGroupInterface> = { scope, isMainList: false, isTestList: true };
             const testTargetGroup = await this.targetGroupRepository.findOne(where);
             const contactIncludesTestList = testTargetGroup?.brevoId ? contact.listIds.includes(testTargetGroup.brevoId) : false;
@@ -292,6 +294,8 @@ export function createBrevoContactResolver({
             @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope)) scope: typeof Scope,
         ): Promise<boolean> {
             const contact = await this.brevoContactsApiService.findContact(id, scope);
+            if (!contact) return false;
+
             const where: FilterQuery<TargetGroupInterface> = { scope, isMainList: false, isTestList: true };
             const testTargetGroup = await this.targetGroupRepository.findOne(where);
             const mainTargetGroup = await this.targetGroupRepository.findOne({ scope, isMainList: true });

--- a/packages/api/src/brevo-contact/brevo-contact.resolver.ts
+++ b/packages/api/src/brevo-contact/brevo-contact.resolver.ts
@@ -288,9 +288,10 @@ export function createBrevoContactResolver({
             const contact = await this.brevoContactsApiService.findContact(id, scope);
             const where: FilterQuery<TargetGroupInterface> = { scope, isMainList: false, isTestList: true };
             const testTargetGroup = await this.targetGroupRepository.findOne(where);
-            const contactIncludesTestList = testTargetGroup?.brevoId ? contact.listIds.includes(testTargetGroup.brevoId) : false;
+            const mainTargetGroup = await this.targetGroupRepository.findOne({ scope, isMainList: true });
+            const mainListIncludesContact = mainTargetGroup?.brevoId ? contact.listIds.includes(mainTargetGroup.brevoId) : false;
 
-            if (testTargetGroup && contactIncludesTestList) {
+            if (testTargetGroup && mainListIncludesContact) {
                 const testListId = testTargetGroup.brevoId;
 
                 const linkListIds = contact.listIds.filter((id) => id !== testListId);

--- a/packages/api/src/brevo-contact/brevo-contact.resolver.ts
+++ b/packages/api/src/brevo-contact/brevo-contact.resolver.ts
@@ -288,9 +288,9 @@ export function createBrevoContactResolver({
             const contact = await this.brevoContactsApiService.findContact(id, scope);
             const where: FilterQuery<TargetGroupInterface> = { scope, isMainList: false, isTestList: true };
             const testTargetGroup = await this.targetGroupRepository.findOne(where);
-            const contactIncludesMainList = testTargetGroup?.brevoId ? contact.listIds.includes(testTargetGroup.brevoId) : false;
+            const contactIncludesTestList = testTargetGroup?.brevoId ? contact.listIds.includes(testTargetGroup.brevoId) : false;
 
-            if (testTargetGroup && contactIncludesMainList) {
+            if (testTargetGroup && contactIncludesTestList) {
                 const testListId = testTargetGroup.brevoId;
 
                 const linkListIds = contact.listIds.filter((id) => id !== testListId);

--- a/packages/api/src/brevo-contact/brevo-contact.resolver.ts
+++ b/packages/api/src/brevo-contact/brevo-contact.resolver.ts
@@ -15,6 +15,7 @@ import { BrevoContactsService } from "./brevo-contacts.service";
 import { BrevoContactInterface } from "./dto/brevo-contact.factory";
 import { BrevoContactInputInterface, BrevoContactUpdateInputInterface } from "./dto/brevo-contact-input.factory";
 import { BrevoContactsArgsFactory } from "./dto/brevo-contacts.args";
+import { BrevoTestContactInputInterface } from "./dto/brevo-test-contact-input.factory";
 import { ManuallyAssignedBrevoContactsArgs } from "./dto/manually-assigned-brevo-contacts.args";
 import { SubscribeInputInterface } from "./dto/subscribe-input.factory";
 import { SubscribeResponse } from "./dto/subscribe-response.enum";
@@ -26,11 +27,13 @@ export function createBrevoContactResolver({
     Scope,
     BrevoContactInput,
     BrevoContactUpdateInput,
+    BrevoTestContactInput,
 }: {
     BrevoContact: Type<BrevoContactInterface>;
     BrevoContactSubscribeInput: Type<SubscribeInputInterface>;
     BrevoContactInput: Type<BrevoContactInputInterface>;
     BrevoContactUpdateInput: Type<Partial<BrevoContactInputInterface>>;
+    BrevoTestContactInput: Type<BrevoTestContactInputInterface>;
     Scope: Type<EmailCampaignScopeInterface>;
 }): Type<unknown> {
     @ObjectType()
@@ -221,7 +224,7 @@ export function createBrevoContactResolver({
         @RequiredPermission(["brevo-newsletter"], { skipScopeCheck: true })
         async createBrevoTestContact(
             @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope)) scope: typeof Scope,
-            @Args("input", { type: () => BrevoContactInput })
+            @Args("input", { type: () => BrevoTestContactInput })
             input: BrevoContactInputInterface,
         ): Promise<SubscribeResponse> {
             const where: FilterQuery<TargetGroupInterface> = { scope, isMainList: false, isTestList: true };

--- a/packages/api/src/brevo-contact/brevo-contacts.service.ts
+++ b/packages/api/src/brevo-contact/brevo-contacts.service.ts
@@ -64,9 +64,7 @@ export class BrevoContactsService {
     }): Promise<boolean> {
         const testTargetGroupForScope = await this.targetGroupService.createIfNotExistTestTargetGroupForScope(scope);
 
-        const brevoIds = [testTargetGroupForScope.brevoId];
-
-        const created = await this.brevoContactsApiService.createTestContact({ email, attributes }, brevoIds, scope);
+        const created = await this.brevoContactsApiService.createTestContact({ email, attributes }, [testTargetGroupForScope.brevoId], scope);
         return created;
     }
 

--- a/packages/api/src/brevo-contact/brevo-contacts.service.ts
+++ b/packages/api/src/brevo-contact/brevo-contacts.service.ts
@@ -53,6 +53,23 @@ export class BrevoContactsService {
         return created;
     }
 
+    public async createTestContact({
+        email,
+        attributes,
+        scope,
+    }: {
+        email: string;
+        attributes?: BrevoContactAttributesInterface;
+        scope: EmailCampaignScopeInterface;
+    }): Promise<boolean> {
+        const testTargetGroupForScope = await this.targetGroupService.createIfNotExistTestTargetGroupForScope(scope);
+
+        const brevoIds = [testTargetGroupForScope.brevoId];
+
+        const created = await this.brevoContactsApiService.createTestContact({ email, attributes }, brevoIds, scope);
+        return created;
+    }
+
     public async getTargetGroupIdsForNewContact({
         contactAttributes,
         scope,

--- a/packages/api/src/brevo-contact/brevo-contacts.service.ts
+++ b/packages/api/src/brevo-contact/brevo-contacts.service.ts
@@ -91,10 +91,9 @@ export class BrevoContactsService {
             offset += targetGroups.length;
 
             for (const targetGroup of targetGroups) {
-                const contactIsInTargetGroup = this.targetGroupService.checkIfContactIsInTargetGroup(
+                const contactIsInTargetGroup = this.targetGroupService.checkIfContactIsInTargetGroupByAttributes(
                     contactAttributes,
                     targetGroup.filters,
-                    assignedContactsTargetGroupBrevoId,
                 );
 
                 if (contactIsInTargetGroup) {
@@ -137,7 +136,7 @@ export class BrevoContactsService {
             offset += targetGroups.length;
 
             for (const targetGroup of targetGroups) {
-                const contactIsInTargetGroupByAttributes = this.targetGroupService.checkIfContactIsInTargetGroup(
+                const contactIsInTargetGroupByAttributes = this.targetGroupService.checkIfContactIsInTargetGroupByAttributes(
                     contact?.attributes,
                     targetGroup.filters,
                 );

--- a/packages/api/src/brevo-contact/brevo-contacts.service.ts
+++ b/packages/api/src/brevo-contact/brevo-contacts.service.ts
@@ -73,9 +73,11 @@ export class BrevoContactsService {
     public async getTargetGroupIdsForNewContact({
         contactAttributes,
         scope,
+        assignedContactsTargetGroupBrevoId,
     }: {
         contactAttributes?: BrevoContactAttributesInterface;
         scope?: EmailCampaignScopeInterface;
+        assignedContactsTargetGroupBrevoId?: number;
     }): Promise<number[]> {
         let offset = 0;
         let totalCount = 0;
@@ -89,7 +91,11 @@ export class BrevoContactsService {
             offset += targetGroups.length;
 
             for (const targetGroup of targetGroups) {
-                const contactIsInTargetGroup = this.targetGroupService.checkIfContactIsInTargetGroup(contactAttributes, targetGroup.filters);
+                const contactIsInTargetGroup = this.targetGroupService.checkIfContactIsInTargetGroup(
+                    contactAttributes,
+                    targetGroup.filters,
+                    assignedContactsTargetGroupBrevoId,
+                );
 
                 if (contactIsInTargetGroup) {
                     targetGroupIds.push(targetGroup.brevoId);

--- a/packages/api/src/brevo-contact/brevo-contacts.service.ts
+++ b/packages/api/src/brevo-contact/brevo-contacts.service.ts
@@ -71,11 +71,9 @@ export class BrevoContactsService {
     public async getTargetGroupIdsForNewContact({
         contactAttributes,
         scope,
-        assignedContactsTargetGroupBrevoId,
     }: {
         contactAttributes?: BrevoContactAttributesInterface;
         scope?: EmailCampaignScopeInterface;
-        assignedContactsTargetGroupBrevoId?: number;
     }): Promise<number[]> {
         let offset = 0;
         let totalCount = 0;

--- a/packages/api/src/brevo-contact/dto/brevo-test-contact-input.factory.ts
+++ b/packages/api/src/brevo-contact/dto/brevo-test-contact-input.factory.ts
@@ -2,7 +2,7 @@ import { IsUndefinable } from "@comet/cms-api";
 import { Type } from "@nestjs/common";
 import { Field, InputType } from "@nestjs/graphql";
 import { Type as TypeTransformer } from "class-transformer";
-import { IsBoolean, IsNotEmpty, IsOptional, IsString, ValidateNested } from "class-validator";
+import { IsBoolean, IsNotEmpty, IsString, ValidateNested } from "class-validator";
 
 import { BrevoContactAttributesInterface, EmailCampaignScopeInterface } from "../../types";
 
@@ -36,7 +36,7 @@ export class BrevoTestContactInputFactory {
 
             @IsBoolean()
             @Field()
-            @IsOptional()
+            @IsUndefinable()
             blocked?: boolean;
         }
 

--- a/packages/api/src/brevo-contact/dto/brevo-test-contact-input.factory.ts
+++ b/packages/api/src/brevo-contact/dto/brevo-test-contact-input.factory.ts
@@ -1,0 +1,61 @@
+import { IsUndefinable } from "@comet/cms-api";
+import { Type } from "@nestjs/common";
+import { Field, InputType } from "@nestjs/graphql";
+import { Type as TypeTransformer } from "class-transformer";
+import { IsBoolean, IsNotEmpty, IsOptional, IsString, ValidateNested } from "class-validator";
+
+import { BrevoContactAttributesInterface, EmailCampaignScopeInterface } from "../../types";
+
+export interface BrevoTestContactInputInterface {
+    email: string;
+    blocked?: boolean;
+    attributes?: BrevoContactAttributesInterface;
+}
+
+export interface BrevoTestContactUpdateInputInterface {
+    blocked?: boolean;
+    attributes?: BrevoContactAttributesInterface;
+}
+
+export class BrevoTestContactInputFactory {
+    static create({
+        BrevoContactAttributes,
+        Scope,
+    }: {
+        BrevoContactAttributes?: Type<BrevoContactAttributesInterface>;
+        Scope: Type<EmailCampaignScopeInterface>;
+    }): [Type<BrevoTestContactInputInterface>] {
+        @InputType({
+            isAbstract: true,
+        })
+        class BrevoTestContactInputBase implements BrevoTestContactInputInterface {
+            @IsNotEmpty()
+            @IsString()
+            @Field()
+            email: string;
+
+            @IsBoolean()
+            @Field()
+            @IsOptional()
+            blocked?: boolean;
+        }
+
+        if (BrevoContactAttributes) {
+            @InputType()
+            class BrevoTestContactInput extends BrevoTestContactInputBase {
+                @Field(() => BrevoContactAttributes, { nullable: true })
+                @TypeTransformer(() => BrevoContactAttributes)
+                @ValidateNested()
+                @IsUndefinable()
+                attributes?: BrevoContactAttributesInterface;
+            }
+
+            return [BrevoTestContactInput];
+        }
+
+        @InputType()
+        class BrevoTestContactInput extends BrevoTestContactInputBase {}
+
+        return [BrevoTestContactInput];
+    }
+}

--- a/packages/api/src/mikro-orm/migrations/Migration20240830112400.ts
+++ b/packages/api/src/mikro-orm/migrations/Migration20240830112400.ts
@@ -2,6 +2,6 @@ import { Migration } from "@mikro-orm/migrations";
 
 export class Migration20240830112400 extends Migration {
     async up(): Promise<void> {
-        this.addSql('alter table "TargetGroup" add column "isTestList" boolean null;');
+        this.addSql('alter table "TargetGroup" add column "isTestList" boolean not null default false;');
     }
 }

--- a/packages/api/src/mikro-orm/migrations/Migration20240830112400.ts
+++ b/packages/api/src/mikro-orm/migrations/Migration20240830112400.ts
@@ -1,0 +1,7 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20240830112400 extends Migration {
+    async up(): Promise<void> {
+        this.addSql('alter table "TargetGroup" add column "isTestList" boolean null;');
+    }
+}

--- a/packages/api/src/mikro-orm/migrations/Migration20240830112400.ts
+++ b/packages/api/src/mikro-orm/migrations/Migration20240830112400.ts
@@ -3,5 +3,7 @@ import { Migration } from "@mikro-orm/migrations";
 export class Migration20240830112400 extends Migration {
     async up(): Promise<void> {
         this.addSql('alter table "TargetGroup" add column "isTestList" boolean not null default false;');
+
+        this.addSql('alter table "TargetGroup" alter column "isTestList" drop default;');
     }
 }

--- a/packages/api/src/mikro-orm/migrations/Migration20240830112400.ts
+++ b/packages/api/src/mikro-orm/migrations/Migration20240830112400.ts
@@ -3,7 +3,5 @@ import { Migration } from "@mikro-orm/migrations";
 export class Migration20240830112400 extends Migration {
     async up(): Promise<void> {
         this.addSql('alter table "TargetGroup" add column "isTestList" boolean not null default false;');
-
-        this.addSql('alter table "TargetGroup" alter column "isTestList" drop default;');
     }
 }

--- a/packages/api/src/mikro-orm/migrations/migrations.ts
+++ b/packages/api/src/mikro-orm/migrations/migrations.ts
@@ -8,6 +8,7 @@ import { Migration20240619092554 } from "./Migration20240619092554";
 import { Migration20240619145217 } from "./Migration20240619145217";
 import { Migration20240621102349 } from "./Migration20240621102349";
 import { Migration20240819214939 } from "./Migration20240819214939";
+import { Migration20240830112400 } from "./Migration20240830112400";
 
 export const migrationsList: MigrationObject[] = [
     { name: "Migration20240115095733", class: Migration20240115095733 },
@@ -18,4 +19,5 @@ export const migrationsList: MigrationObject[] = [
     { name: "Migration20240619145217", class: Migration20240619145217 },
     { name: "Migration20240621102349", class: Migration20240621102349 },
     { name: "Migration20240819214939", class: Migration20240819214939 },
+    { name: "Migration20240830112400", class: Migration20240830112400 },
 ];

--- a/packages/api/src/target-group/dto/target-group.filter.ts
+++ b/packages/api/src/target-group/dto/target-group.filter.ts
@@ -1,4 +1,4 @@
-import { DateFilter, StringFilter } from "@comet/cms-api";
+import { BooleanFilter, DateFilter, StringFilter } from "@comet/cms-api";
 import { Field, InputType } from "@nestjs/graphql";
 import { Type } from "class-transformer";
 import { IsOptional, ValidateNested } from "class-validator";
@@ -22,6 +22,12 @@ export class TargetGroupFilter {
     @IsOptional()
     @Type(() => StringFilter)
     title?: StringFilter;
+
+    @Field(() => BooleanFilter, { nullable: true })
+    @ValidateNested()
+    @IsOptional()
+    @Type(() => BooleanFilter)
+    isTestList?: BooleanFilter;
 
     @Field(() => [TargetGroupFilter], { nullable: true })
     @Type(() => TargetGroupFilter)

--- a/packages/api/src/target-group/entity/target-group-entity.factory.ts
+++ b/packages/api/src/target-group/entity/target-group-entity.factory.ts
@@ -21,6 +21,7 @@ export interface TargetGroupInterface {
     filters?: BrevoContactFilterAttributesInterface;
     assignedContactsTargetGroupBrevoId?: number;
     campaigns: Collection<EmailCampaignInterface, object>;
+    isTestList?: boolean;
 }
 
 export class TargetGroupEntityFactory {
@@ -58,6 +59,10 @@ export class TargetGroupEntityFactory {
             @Property({ columnType: "boolean" })
             @Field()
             isMainList: boolean;
+
+            @Property({ columnType: "boolean", nullable: true })
+            @Field({ nullable: true })
+            isTestList: boolean;
 
             @Property({ columnType: "int" })
             @Field(() => Int)

--- a/packages/api/src/target-group/entity/target-group-entity.factory.ts
+++ b/packages/api/src/target-group/entity/target-group-entity.factory.ts
@@ -21,7 +21,7 @@ export interface TargetGroupInterface {
     filters?: BrevoContactFilterAttributesInterface;
     assignedContactsTargetGroupBrevoId?: number;
     campaigns: Collection<EmailCampaignInterface, object>;
-    isTestList?: boolean;
+    isTestList: boolean;
 }
 
 export class TargetGroupEntityFactory {
@@ -60,8 +60,8 @@ export class TargetGroupEntityFactory {
             @Field()
             isMainList: boolean;
 
-            @Property({ columnType: "boolean", nullable: true })
-            @Field({ nullable: true })
+            @Property({ columnType: "boolean" })
+            @Field()
             isTestList: boolean;
 
             @Property({ columnType: "int" })

--- a/packages/api/src/target-group/target-group.resolver.ts
+++ b/packages/api/src/target-group/target-group.resolver.ts
@@ -92,7 +92,7 @@ export function createTargetGroupsResolver({
             const brevoId = await this.brevoApiContactsService.createBrevoContactList(input.title, scope);
 
             if (brevoId) {
-                const targetGroup = this.repository.create({ ...input, brevoId, scope, isMainList: false });
+                const targetGroup = this.repository.create({ ...input, brevoId, scope, isMainList: false, isTestList: false });
 
                 await this.entityManager.flush();
 

--- a/packages/api/src/target-group/target-group.resolver.ts
+++ b/packages/api/src/target-group/target-group.resolver.ts
@@ -52,6 +52,7 @@ export function createTargetGroupsResolver({
         async targetGroups(@Args() { search, filter, sort, offset, limit, scope }: TargetGroupsArgs): Promise<PaginatedTargetGroups> {
             const where = this.targetGroupsService.getFindCondition({ search, filter });
             where.scope = scope;
+            where.isTestList = false;
 
             const options: FindOptions<TargetGroupInterface> = { offset, limit };
 

--- a/packages/api/src/target-group/target-group.resolver.ts
+++ b/packages/api/src/target-group/target-group.resolver.ts
@@ -140,7 +140,7 @@ export function createTargetGroupsResolver({
                 throw new Error("No assigned contacts target group found");
             }
 
-            const contactIsInTargetGroupByAttributes = this.targetGroupsService.checkIfContactIsInTargetGroup(
+            const contactIsInTargetGroupByAttributes = this.targetGroupsService.checkIfContactIsInTargetGroupByAttributes(
                 brevoContact.attributes,
                 targetGroup.filters,
             );

--- a/packages/api/src/target-group/target-groups.service.ts
+++ b/packages/api/src/target-group/target-groups.service.ts
@@ -30,6 +30,10 @@ export class TargetGroupsService {
             andFilters.push(filtersToMikroOrmQuery(options.filter));
         }
 
+        if (!options.filter?.isTestList) {
+            andFilters.push({ isTestList: { $ne: true } });
+        }
+
         return andFilters.length > 0 ? { $and: andFilters } : {};
     }
 

--- a/packages/api/src/target-group/target-groups.service.ts
+++ b/packages/api/src/target-group/target-groups.service.ts
@@ -30,10 +30,6 @@ export class TargetGroupsService {
             andFilters.push(filtersToMikroOrmQuery(options.filter));
         }
 
-        if (!options.filter?.isTestList) {
-            andFilters.push({ isTestList: { $ne: true } });
-        }
-
         return andFilters.length > 0 ? { $and: andFilters } : {};
     }
 

--- a/packages/api/src/target-group/target-groups.service.ts
+++ b/packages/api/src/target-group/target-groups.service.ts
@@ -2,6 +2,7 @@ import { filtersToMikroOrmQuery, searchToMikroOrmQuery } from "@comet/cms-api";
 import { EntityManager, EntityRepository, FilterQuery, ObjectQuery, wrap } from "@mikro-orm/core";
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { Injectable } from "@nestjs/common";
+import { stringify } from "querystring";
 
 import { BrevoApiContactsService } from "../brevo-api/brevo-api-contact.service";
 import { BrevoContactInterface } from "../brevo-contact/dto/brevo-contact.factory";
@@ -157,9 +158,7 @@ export class TargetGroupsService {
             return testList;
         }
 
-        const title = `Test list for scope: ${scope.country ? `${scope.country} (country)` : ""}${
-            scope.language ? ` ${scope.language} (language)` : ""
-        }${scope.brand ? ` ${scope.brand} (brand)` : ""}`;
+        const title = `Test list for scope: ${stringify(scope)}`;
 
         const brevoId = await this.brevoApiContactsService.createBrevoContactList(title, scope);
 

--- a/packages/api/src/target-group/target-groups.service.ts
+++ b/packages/api/src/target-group/target-groups.service.ts
@@ -31,13 +31,10 @@ export class TargetGroupsService {
         return andFilters.length > 0 ? { $and: andFilters } : {};
     }
 
-    public checkIfContactIsInTargetGroup(
+    public checkIfContactIsInTargetGroupByAttributes(
         contactAttributes?: BrevoContactAttributesInterface,
         filters?: BrevoContactFilterAttributesInterface,
-        assignedContactsTargetGroupBrevoId?: number,
     ): boolean {
-        if (!contactAttributes || !assignedContactsTargetGroupBrevoId) return false;
-
         if (filters && contactAttributes) {
             for (const [key, value] of Object.entries(filters)) {
                 if (!value || value.length === 0) continue;
@@ -87,7 +84,7 @@ export class TargetGroupsService {
             const contactsNotInContactList: BrevoContactInterface[] = [];
 
             for (const contact of contacts) {
-                const contactIsInTargetGroupByFilters = this.checkIfContactIsInTargetGroup(contact.attributes, filters);
+                const contactIsInTargetGroupByFilters = this.checkIfContactIsInTargetGroupByAttributes(contact.attributes, filters);
 
                 const manuallyAssignedTargetGroup = targetGroup.assignedContactsTargetGroupBrevoId;
                 const contactIsManuallyAssignedToTargetGroup = manuallyAssignedTargetGroup

--- a/packages/api/src/target-group/target-groups.service.ts
+++ b/packages/api/src/target-group/target-groups.service.ts
@@ -150,6 +150,27 @@ export class TargetGroupsService {
         throw new Error("Brevo Error: Could not create contact list");
     }
 
+    public async createIfNotExistTestTargetGroupForScope(scope: EmailCampaignScopeInterface): Promise<TargetGroupInterface> {
+        const testList = await this.repository.findOne({ scope, isMainList: false, title: "Test list for current scope" });
+
+        if (testList) {
+            return testList;
+        }
+
+        const title = "Test list for current scope";
+        const brevoId = await this.brevoApiContactsService.createBrevoContactList(title, scope);
+
+        if (brevoId) {
+            const testTargetGroupForScope = this.repository.create({ title, brevoId, scope, isMainList: false });
+
+            await this.entityManager.flush();
+
+            return testTargetGroupForScope;
+        }
+
+        throw new Error("Brevo Error: Could not create contact list");
+    }
+
     public async createIfNotExistsManuallyAssignedContactsTargetGroup(targetGroup: TargetGroupInterface) {
         if (targetGroup.assignedContactsTargetGroupBrevoId) {
             return targetGroup.assignedContactsTargetGroupBrevoId;

--- a/packages/api/src/target-group/target-groups.service.ts
+++ b/packages/api/src/target-group/target-groups.service.ts
@@ -141,7 +141,7 @@ export class TargetGroupsService {
         const brevoId = await this.brevoApiContactsService.createBrevoContactList(title, scope);
 
         if (brevoId) {
-            const mainTargetGroupForScope = this.repository.create({ title, brevoId, scope, isMainList: true });
+            const mainTargetGroupForScope = this.repository.create({ title, brevoId, scope, isMainList: true, isTestList: false });
 
             await this.entityManager.flush();
 

--- a/packages/api/src/target-group/target-groups.service.ts
+++ b/packages/api/src/target-group/target-groups.service.ts
@@ -34,7 +34,10 @@ export class TargetGroupsService {
     public checkIfContactIsInTargetGroup(
         contactAttributes?: BrevoContactAttributesInterface,
         filters?: BrevoContactFilterAttributesInterface,
+        assignedContactsTargetGroupBrevoId?: number,
     ): boolean {
+        if (!contactAttributes || !assignedContactsTargetGroupBrevoId) return false;
+
         if (filters && contactAttributes) {
             for (const [key, value] of Object.entries(filters)) {
                 if (!value || value.length === 0) continue;

--- a/packages/api/src/target-group/target-groups.service.ts
+++ b/packages/api/src/target-group/target-groups.service.ts
@@ -157,7 +157,10 @@ export class TargetGroupsService {
             return testList;
         }
 
-        const title = "Test list for current scope";
+        const title = `Test list for scope: ${scope.country ? `${scope.country} (country)` : ""}${
+            scope.language ? ` ${scope.language} (language)` : ""
+        }${scope.brand ? ` ${scope.brand} (brand)` : ""}`;
+
         const brevoId = await this.brevoApiContactsService.createBrevoContactList(title, scope);
 
         if (brevoId) {

--- a/packages/api/src/target-group/target-groups.service.ts
+++ b/packages/api/src/target-group/target-groups.service.ts
@@ -154,7 +154,7 @@ export class TargetGroupsService {
     }
 
     public async createIfNotExistTestTargetGroupForScope(scope: EmailCampaignScopeInterface): Promise<TargetGroupInterface> {
-        const testList = await this.repository.findOne({ scope, isMainList: false, title: "Test list for current scope" });
+        const testList = await this.repository.findOne({ scope, isMainList: false, isTestList: true });
 
         if (testList) {
             return testList;
@@ -164,7 +164,7 @@ export class TargetGroupsService {
         const brevoId = await this.brevoApiContactsService.createBrevoContactList(title, scope);
 
         if (brevoId) {
-            const testTargetGroupForScope = this.repository.create({ title, brevoId, scope, isMainList: false });
+            const testTargetGroupForScope = this.repository.create({ title, brevoId, scope, isMainList: false, isTestList: true });
 
             await this.entityManager.flush();
 


### PR DESCRIPTION
-   [x] Add changeset (if necessary)

- Create a test contact list
- Fix: if a contact is added to the main list, it was added to all lists without filters. Added a check for manuallyAssignedContacts.
- Contacts added to a test list, don't need a double opt-in.
- If a contact is added to the test list, it is possible to add it to the main list as well. Then a DOI is sent.
- Test list is not displayed in the target group page.

