### PR TITLE
Prevent invisible blocks from being included in the newsletter

### DIFF
--- a/.changeset/moody-pumas-wash.md
+++ b/.changeset/moody-pumas-wash.md
@@ -1,0 +1,5 @@
+---
+"@comet/brevo-api": patch
+---
+
+Prevent invisible blocks from being included in the newsletter

--- a/packages/api/src/email-campaign/email-campaigns.service.ts
+++ b/packages/api/src/email-campaign/email-campaigns.service.ts
@@ -43,7 +43,10 @@ export class EmailCampaignsService {
     }
 
     async saveEmailCampaignInBrevo(campaign: EmailCampaignInterface, scheduledAt?: Date): Promise<EmailCampaignInterface> {
-        const content = await this.blockTransformerService.transformToPlain(campaign.content);
+        const content = await this.blockTransformerService.transformToPlain(campaign.content, {
+            includeInvisibleContent: false,
+            previewDamUrls: false,
+        });
 
         const { data: htmlContent, status } = await this.httpService.axiosRef.post(
             this.config.emailCampaigns.frontend.url,


### PR DESCRIPTION
Previously, invisible blocks where still included in the newsletter. This could lead to unwanted content being in the newsletter.

---

COM-1056