### PR TITLE
Fix campaign statistics - use campaignStats instead of globalStats

### DIFF
--- a/.changeset/six-rivers-sip.md
+++ b/.changeset/six-rivers-sip.md
@@ -2,6 +2,6 @@
 "@comet/brevo-api": patch
 ---
 
-Fix Campaign Statistics.
+Fix campaign statistics
 
 Addressed an issue where the globalStats property was being used to retrieve campaign stats, but it wasn’t working as expected. We now use the campaignStats property instead, which returns a list. The first value from this list is now used to show accurate campaign statistics.

--- a/.changeset/six-rivers-sip.md
+++ b/.changeset/six-rivers-sip.md
@@ -1,0 +1,7 @@
+---
+"@comet/brevo-api": patch
+---
+
+Fix Campaign Statistics.
+
+Addressed an issue where the globalStats property was being used to retrieve campaign stats, but it wasn’t working as expected. We now use the campaignStats property instead, which returns a list. The first value from this list is now used to show accurate campaign statistics.

--- a/packages/api/src/brevo-api/brevo-api-campaigns.service.ts
+++ b/packages/api/src/brevo-api/brevo-api-campaigns.service.ts
@@ -167,7 +167,10 @@ export class BrevoApiCampaignsService {
 
         const brevoCampaign = await this.loadBrevoCampaignById(campaign);
 
-        return brevoCampaign.statistics.globalStats;
+        // The property globalStats seems to be right here according to the docs: https://developers.brevo.com/reference/getemailcampaign
+        // Unforunately, the API returns only 0 values for the globalStats property.
+        // That's why we return the first element of the campaignStats array, which contains the correct values.
+        return brevoCampaign.statistics.campaignStats[0];
     }
 
     private async *getCampaignsResponse(

--- a/packages/api/src/brevo-api/dto/brevo-api-campaign.ts
+++ b/packages/api/src/brevo-api/dto/brevo-api-campaign.ts
@@ -1,5 +1,20 @@
 import { GetEmailCampaignsCampaignsInner } from "@getbrevo/brevo";
 
+interface BrevoStatistics {
+    uniqueClicks: number;
+    clickers: number;
+    complaints: number;
+    delivered: number;
+    sent: number;
+    softBounces: number;
+    hardBounces: number;
+    uniqueViews: number;
+    trackableViews: number;
+    estimatedViews?: number;
+    unsubscriptions: number;
+    viewed: number;
+}
+
 export interface BrevoApiCampaign {
     id: number;
     name: string;
@@ -7,20 +22,8 @@ export interface BrevoApiCampaign {
     type: GetEmailCampaignsCampaignsInner.TypeEnum;
     status: GetEmailCampaignsCampaignsInner.StatusEnum;
     statistics: {
-        globalStats: {
-            uniqueClicks: number;
-            clickers: number;
-            complaints: number;
-            delivered: number;
-            sent: number;
-            softBounces: number;
-            hardBounces: number;
-            uniqueViews: number;
-            trackableViews: number;
-            estimatedViews?: number;
-            unsubscriptions: number;
-            viewed: number;
-        };
+        globalStats: BrevoStatistics; // Overall statistics of the campaign
+        campaignStats: BrevoStatistics[]; // List-wise statistics of the campaign.
     };
     sentDate?: string;
     scheduledAt?: string;


### PR DESCRIPTION
COM-1070

This is the response we get:
![image](https://github.com/user-attachments/assets/cb48e3a3-688f-493e-bd04-7a88b07ddde4)
