### PR TITLE
Fix contact search - do not throw an error if contact is not found

### DIFF
--- a/.changeset/sweet-geese-tease.md
+++ b/.changeset/sweet-geese-tease.md
@@ -1,0 +1,7 @@
+---
+"@comet/brevo-api": patch
+---
+
+Fix searching contacts
+
+Previously, Brevo returned a 400 error when an email address was not found. The implementation has been updated to correctly handle the 404 status code instead of 400. As a result, the contact search functionality now works as expected without throwing an error when no matching email address is found.

--- a/packages/api/src/brevo-api/brevo-api-contact.service.ts
+++ b/packages/api/src/brevo-api/brevo-api-contact.service.ts
@@ -95,8 +95,8 @@ export class BrevoApiContactsService {
             if (!contact) return undefined;
             return contact;
         } catch (error) {
-            // Brevo throws 400 error if no contact was found
-            if (isErrorFromBrevo(error) && error.response.statusCode === 400) {
+            // Brevo throws 404 error if no contact was found
+            if (isErrorFromBrevo(error) && error.response.statusCode === 404) {
                 return undefined;
             }
             throw error;


### PR DESCRIPTION
COM-1071

Previously, Brevo returned a 400 error when an email address was not found. The implementation has been updated to correctly handle the 404 status code instead of 400. As a result, the contact search functionality now works as expected without throwing an error when no matching email address is found.

-   [x] Add changeset (if necessary)
