### PR TITLE
COM-964: support multiselect in contact attributes

### DIFF
--- a/.changeset/fifty-radios-wonder.md
+++ b/.changeset/fifty-radios-wonder.md
@@ -1,0 +1,7 @@
+---
+"@comet/brevo-api": minor
+---
+
+Add check for arrays in `checkIfContactIsInTargetGroup` function, to check if at least one `contactAttribute` is included in the filter.
+
+Pass `scope` to `getTargetGroupIdsForExistingContact`.

--- a/.changeset/fifty-radios-wonder.md
+++ b/.changeset/fifty-radios-wonder.md
@@ -3,5 +3,3 @@
 ---
 
 Add check for arrays in `checkIfContactIsInTargetGroup` function, to check if at least one `contactAttribute` is included in the filter.
-
-Pass `scope` to `getTargetGroupIdsForExistingContact`.

--- a/.changeset/fifty-radios-wonder.md
+++ b/.changeset/fifty-radios-wonder.md
@@ -1,5 +1,5 @@
 ---
-"@comet/brevo-api": minor
+"@comet/brevo-api": patch
 ---
 
 Add check for arrays in `checkIfContactIsInTargetGroup` function, to check if at least one `contactAttribute` is included in the filter.

--- a/demo/admin/src/common/brevoModuleConfig/brevoContactsPageAttributesConfig.tsx
+++ b/demo/admin/src/common/brevoModuleConfig/brevoContactsPageAttributesConfig.tsx
@@ -2,7 +2,7 @@ import { Field, FinalFormSelect, TextField } from "@comet/admin";
 import { EditBrevoContactFormValues } from "@comet/brevo-admin";
 import { MenuItem } from "@mui/material";
 import { GridColDef } from "@mui/x-data-grid";
-import { GQLBrevoContactSalutation } from "@src/graphql.generated";
+import { GQLBrevoContactBranch, GQLBrevoContactSalutation } from "@src/graphql.generated";
 import { DocumentNode } from "graphql";
 import gql from "graphql-tag";
 import React from "react";
@@ -16,6 +16,7 @@ const attributesFragment = gql`
             LASTNAME
             FIRSTNAME
             SALUTATION
+            BRANCH
         }
     }
 `;
@@ -31,8 +32,24 @@ const salutationOptions: Array<{ label: React.ReactNode; value: GQLBrevoContactS
     },
 ];
 
+const branchOptions: Array<{ label: React.ReactNode; value: GQLBrevoContactBranch }> = [
+    {
+        label: <FormattedMessage id="brevoContact.filters.branch.products" defaultMessage="Products" />,
+        value: "PRODUCTS",
+    },
+    {
+        label: <FormattedMessage id="brevoContact.filters.branch.marketing" defaultMessage="Marketing" />,
+        value: "MARKETING",
+    },
+    {
+        label: <FormattedMessage id="brevoContact.filters.branch.news" defaultMessage="News" />,
+        value: "NEWS",
+    },
+];
+
 interface AdditionalFormConfigInputProps extends EditBrevoContactFormValues {
     attributes: {
+        BRANCH?: Array<GQLBrevoContactBranch>;
         SALUTATION?: GQLBrevoContactSalutation;
         FIRSTNAME?: string;
         LASTNAME?: string;
@@ -55,7 +72,7 @@ export const getBrevoContactConfig = (
     input2State: (values?: AdditionalFormConfigInputProps) => {
         email: string;
         redirectionUrl: string;
-        attributes: { SALUTATION?: GQLBrevoContactSalutation; FIRSTNAME?: string; LASTNAME?: string };
+        attributes: { BRANCH?: Array<GQLBrevoContactBranch>; SALUTATION?: GQLBrevoContactSalutation; FIRSTNAME?: string; LASTNAME?: string };
     };
     exportFields: {
         renderValue: (row: GQLBrevoContactAttributesFragmentFragment) => string;
@@ -98,6 +115,17 @@ export const getBrevoContactConfig = (
                         </FinalFormSelect>
                     )}
                 </Field>
+                <Field label={<FormattedMessage id="brevoContact.fields.branch" defaultMessage="Branch" />} name="attributes.BRANCH" fullWidth>
+                    {(props) => (
+                        <FinalFormSelect {...props} fullWidth multiple>
+                            {branchOptions.map((option) => (
+                                <MenuItem value={option.value} key={option.value}>
+                                    {option.label}
+                                </MenuItem>
+                            ))}
+                        </FinalFormSelect>
+                    )}
+                </Field>
                 <TextField
                     label={<FormattedMessage id="brevoContact.fields.salutation" defaultMessage="First name" />}
                     name="attributes.FIRSTNAME"
@@ -115,6 +143,7 @@ export const getBrevoContactConfig = (
                 email: values?.email ?? "",
                 redirectionUrl: values?.redirectionUrl ?? "",
                 attributes: {
+                    BRANCH: values?.attributes?.BRANCH ?? [],
                     SALUTATION: values?.attributes?.SALUTATION,
                     FIRSTNAME: values?.attributes?.FIRSTNAME,
                     LASTNAME: values?.attributes?.LASTNAME,

--- a/demo/admin/src/common/brevoModuleConfig/targetGroupFormConfig.tsx
+++ b/demo/admin/src/common/brevoModuleConfig/targetGroupFormConfig.tsx
@@ -2,7 +2,7 @@ import { gql } from "@apollo/client";
 import { Field, FinalFormSelect } from "@comet/admin";
 import { EditTargetGroupFinalFormValues } from "@comet/brevo-admin";
 import { MenuItem } from "@mui/material";
-import { GQLBrevoContactSalutation } from "@src/graphql.generated";
+import { GQLBrevoContactBranch, GQLBrevoContactSalutation } from "@src/graphql.generated";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
@@ -17,11 +17,27 @@ const salutationOptions: Array<{ label: React.ReactNode; value: GQLBrevoContactS
     },
 ];
 
+const branchOptions: Array<{ label: React.ReactNode; value: GQLBrevoContactBranch }> = [
+    {
+        label: <FormattedMessage id="brevoContact.filters.branch.products" defaultMessage="Products" />,
+        value: "PRODUCTS",
+    },
+    {
+        label: <FormattedMessage id="brevoContact.filters.branch.marketing" defaultMessage="Marketing" />,
+        value: "MARKETING",
+    },
+    {
+        label: <FormattedMessage id="brevoContact.filters.branch.news" defaultMessage="News" />,
+        value: "NEWS",
+    },
+];
+
 export const additionalPageTreeNodeFieldsFragment = {
     fragment: gql`
         fragment TargetGroupFilters on TargetGroup {
             filters {
                 SALUTATION
+                BRANCH
             }
         }
     `,
@@ -31,6 +47,7 @@ export const additionalPageTreeNodeFieldsFragment = {
 interface AdditionalFormConfigInputProps extends EditTargetGroupFinalFormValues {
     filters: {
         SALUTATION: Array<GQLBrevoContactSalutation>;
+        BRANCH: Array<GQLBrevoContactBranch>;
     };
 }
 
@@ -40,6 +57,7 @@ export const additionalFormConfig = {
             title: values?.title ?? "",
             filters: {
                 SALUTATION: values?.filters?.SALUTATION ?? [],
+                BRANCH: values?.filters?.BRANCH ?? [],
             },
         };
     },
@@ -50,6 +68,17 @@ export const additionalFormConfig = {
                 {(props) => (
                     <FinalFormSelect {...props} fullWidth multiple clearable>
                         {salutationOptions.map((option) => (
+                            <MenuItem value={option.value} key={option.value}>
+                                {option.label}
+                            </MenuItem>
+                        ))}
+                    </FinalFormSelect>
+                )}
+            </Field>
+            <Field label={<FormattedMessage id="targetGroup.fields.branch" defaultMessage="Branch" />} name="filters.BRANCH" fullWidth>
+                {(props) => (
+                    <FinalFormSelect {...props} fullWidth clearable multiple>
+                        {branchOptions.map((option) => (
                             <MenuItem value={option.value} key={option.value}>
                                 {option.label}
                             </MenuItem>

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -281,11 +281,18 @@ type BrevoContactAttributes {
   LASTNAME: String!
   FIRSTNAME: String!
   SALUTATION: BrevoContactSalutation
+  BRANCH: [BrevoContactBranch!]
 }
 
 enum BrevoContactSalutation {
   MALE
   FEMALE
+}
+
+enum BrevoContactBranch {
+  PRODUCTS
+  MARKETING
+  NEWS
 }
 
 type BrevoContactFilterAttributes {
@@ -470,6 +477,7 @@ input BrevoContactAttributesInput {
   LASTNAME: String!
   FIRSTNAME: String!
   SALUTATION: BrevoContactSalutation
+  BRANCH: [BrevoContactBranch!]
 }
 
 input BrevoContactFilterAttributesInput {

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -297,6 +297,7 @@ enum BrevoContactBranch {
 
 type BrevoContactFilterAttributes {
   SALUTATION: [BrevoContactSalutation!]
+  BRANCH: [BrevoContactBranch!]
 }
 
 type DamFolder {
@@ -482,6 +483,7 @@ input BrevoContactAttributesInput {
 
 input BrevoContactFilterAttributesInput {
   SALUTATION: [BrevoContactSalutation!]
+  BRANCH: [BrevoContactBranch!]
 }
 
 input EmailCampaignContentScopeInput {

--- a/demo/api/src/brevo-contact/dto/brevo-contact-attributes.ts
+++ b/demo/api/src/brevo-contact/dto/brevo-contact-attributes.ts
@@ -43,4 +43,10 @@ export class BrevoContactFilterAttributes {
     @Enum({ items: () => BrevoContactSalutation, array: true })
     @IsUndefinable()
     SALUTATION?: BrevoContactSalutation[];
+
+    @Field(() => [BrevoContactBranch], { nullable: true })
+    @IsEnum(BrevoContactBranch, { each: true })
+    @Enum({ items: () => BrevoContactBranch, array: true })
+    @IsUndefinable()
+    BRANCH?: BrevoContactBranch[];
 }

--- a/demo/api/src/brevo-contact/dto/brevo-contact-attributes.ts
+++ b/demo/api/src/brevo-contact/dto/brevo-contact-attributes.ts
@@ -3,7 +3,7 @@ import { Embeddable, Enum } from "@mikro-orm/core";
 import { Field, InputType, ObjectType } from "@nestjs/graphql";
 import { IsEnum, IsNotEmpty, IsString } from "class-validator";
 
-import { BrevoContactSalutation } from "./brevo-contact.enums";
+import { BrevoContactBranch, BrevoContactSalutation } from "./brevo-contact.enums";
 
 @ObjectType()
 @InputType("BrevoContactAttributesInput")
@@ -22,6 +22,12 @@ export class BrevoContactAttributes {
     @IsEnum(BrevoContactSalutation)
     @IsUndefinable()
     SALUTATION?: BrevoContactSalutation;
+
+    @Field(() => [BrevoContactBranch], { nullable: true })
+    @IsEnum(BrevoContactBranch, { each: true })
+    @Enum({ items: () => BrevoContactBranch, array: true })
+    @IsUndefinable()
+    BRANCH?: BrevoContactBranch[];
 }
 
 @Embeddable()

--- a/demo/api/src/brevo-contact/dto/brevo-contact.enums.ts
+++ b/demo/api/src/brevo-contact/dto/brevo-contact.enums.ts
@@ -8,3 +8,13 @@ export enum BrevoContactSalutation {
 registerEnumType(BrevoContactSalutation, {
     name: "BrevoContactSalutation",
 });
+
+export enum BrevoContactBranch {
+    PRODUCTS = "PRODUCTS",
+    MARKETING = "MARKETING",
+    NEWS = "NEWS",
+}
+
+registerEnumType(BrevoContactBranch, {
+    name: "BrevoContactBranch",
+});

--- a/demo/api/src/db/migrations/Migration20240920122039.ts
+++ b/demo/api/src/db/migrations/Migration20240920122039.ts
@@ -1,0 +1,7 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20240920122039 extends Migration {
+    async up(): Promise<void> {
+        this.addSql('alter table "TargetGroup" add column "filters_BRANCH" text[] null;');
+    }
+}

--- a/packages/api/src/brevo-contact/brevo-contact.resolver.ts
+++ b/packages/api/src/brevo-contact/brevo-contact.resolver.ts
@@ -143,7 +143,6 @@ export function createBrevoContactResolver({
 
             const updatedNonMainListIds = await this.brevoContactsService.getTargetGroupIdsForExistingContact({
                 contact,
-                scope,
             });
 
             // update contact again with updated list ids depending on new attributes

--- a/packages/api/src/brevo-contact/brevo-contact.resolver.ts
+++ b/packages/api/src/brevo-contact/brevo-contact.resolver.ts
@@ -143,6 +143,7 @@ export function createBrevoContactResolver({
 
             const updatedNonMainListIds = await this.brevoContactsService.getTargetGroupIdsForExistingContact({
                 contact,
+                scope,
             });
 
             // update contact again with updated list ids depending on new attributes

--- a/packages/api/src/brevo-contact/brevo-contacts.service.ts
+++ b/packages/api/src/brevo-contact/brevo-contacts.service.ts
@@ -106,13 +106,13 @@ export class BrevoContactsService {
         scope,
     }: {
         contact?: BrevoContactInterface;
-        scope: EmailCampaignScopeInterface;
+        scope?: EmailCampaignScopeInterface;
     }): Promise<number[]> {
         let offset = 0;
         let totalCount = 0;
         const targetGroupIds: number[] = [];
         const limit = 50;
-        const where = { isMainList: false, scope };
+        const where = { isMainList: false };
 
         do {
             const [targetGroups, totalContactLists] = await this.targetGroupService.findTargetGroups({ offset, limit, where });

--- a/packages/api/src/brevo-contact/brevo-contacts.service.ts
+++ b/packages/api/src/brevo-contact/brevo-contacts.service.ts
@@ -128,6 +128,10 @@ export class BrevoContactsService {
                 if (contactIsInTargetGroupByAttributes) {
                     targetGroupIds.push(targetGroup.brevoId);
                 }
+
+                if (targetGroup.assignedContactsTargetGroupBrevoId && contact?.listIds.includes(targetGroup.assignedContactsTargetGroupBrevoId)) {
+                    targetGroupIds.push(targetGroup.brevoId, targetGroup.assignedContactsTargetGroupBrevoId);
+                }
             }
         } while (offset < totalCount);
 

--- a/packages/api/src/brevo-contact/brevo-contacts.service.ts
+++ b/packages/api/src/brevo-contact/brevo-contacts.service.ts
@@ -101,13 +101,7 @@ export class BrevoContactsService {
         return SubscribeResponse.ERROR_UNKNOWN;
     }
 
-    public async getTargetGroupIdsForExistingContact({
-        contact,
-        scope,
-    }: {
-        contact?: BrevoContactInterface;
-        scope?: EmailCampaignScopeInterface;
-    }): Promise<number[]> {
+    public async getTargetGroupIdsForExistingContact({ contact }: { contact?: BrevoContactInterface }): Promise<number[]> {
         let offset = 0;
         let totalCount = 0;
         const targetGroupIds: number[] = [];

--- a/packages/api/src/brevo-contact/brevo-contacts.service.ts
+++ b/packages/api/src/brevo-contact/brevo-contacts.service.ts
@@ -106,7 +106,7 @@ export class BrevoContactsService {
         scope,
     }: {
         contact?: BrevoContactInterface;
-        scope?: EmailCampaignScopeInterface;
+        scope: EmailCampaignScopeInterface;
     }): Promise<number[]> {
         let offset = 0;
         let totalCount = 0;
@@ -120,17 +120,10 @@ export class BrevoContactsService {
             offset += targetGroups.length;
 
             for (const targetGroup of targetGroups) {
-                const contactIsInTargetGroupByAttributes = this.targetGroupService.checkIfContactIsInTargetGroup(
-                    contact?.attributes,
-                    targetGroup.filters,
-                );
+                const contactIsInTargetGroup = this.targetGroupService.checkIfContactIsInTargetGroup(contact?.attributes, targetGroup.filters);
 
-                if (contactIsInTargetGroupByAttributes) {
+                if (contactIsInTargetGroup) {
                     targetGroupIds.push(targetGroup.brevoId);
-                }
-
-                if (targetGroup.assignedContactsTargetGroupBrevoId && contact?.listIds.includes(targetGroup.assignedContactsTargetGroupBrevoId)) {
-                    targetGroupIds.push(targetGroup.brevoId, targetGroup.assignedContactsTargetGroupBrevoId);
                 }
             }
         } while (offset < totalCount);

--- a/packages/api/src/brevo-contact/brevo-contacts.service.ts
+++ b/packages/api/src/brevo-contact/brevo-contacts.service.ts
@@ -120,9 +120,12 @@ export class BrevoContactsService {
             offset += targetGroups.length;
 
             for (const targetGroup of targetGroups) {
-                const contactIsInTargetGroup = this.targetGroupService.checkIfContactIsInTargetGroup(contact?.attributes, targetGroup.filters);
+                const contactIsInTargetGroupByAttributes = this.targetGroupService.checkIfContactIsInTargetGroup(
+                    contact?.attributes,
+                    targetGroup.filters,
+                );
 
-                if (contactIsInTargetGroup) {
+                if (contactIsInTargetGroupByAttributes) {
                     targetGroupIds.push(targetGroup.brevoId);
                 }
             }

--- a/packages/api/src/target-group/target-groups.service.ts
+++ b/packages/api/src/target-group/target-groups.service.ts
@@ -42,12 +42,11 @@ export class TargetGroupsService {
                 if (Array.isArray(contactAttributes[key])) {
                     for (const attribute of contactAttributes[key]) {
                         if (value.includes(attribute)) {
-                            return true;
+                            break;
                         }
                     }
-                }
-
-                if (value.includes(contactAttributes[key])) {
+                    continue;
+                } else if (value.includes(contactAttributes[key])) {
                     continue;
                 }
                 return false;

--- a/packages/api/src/target-group/target-groups.service.ts
+++ b/packages/api/src/target-group/target-groups.service.ts
@@ -37,16 +37,23 @@ export class TargetGroupsService {
     ): boolean {
         if (filters && contactAttributes) {
             for (const [key, value] of Object.entries(filters)) {
-                if (!value) continue;
+                if (!value || value.length === 0) continue;
+
+                if (Array.isArray(contactAttributes[key])) {
+                    for (const attribute of contactAttributes[key]) {
+                        if (value.includes(attribute)) {
+                            return true;
+                        }
+                    }
+                }
+
                 if (value.includes(contactAttributes[key])) {
                     continue;
                 }
-
                 return false;
             }
             return true;
         }
-
         return false;
     }
 

--- a/packages/api/src/target-group/target-groups.service.ts
+++ b/packages/api/src/target-group/target-groups.service.ts
@@ -39,13 +39,18 @@ export class TargetGroupsService {
             for (const [key, value] of Object.entries(filters)) {
                 if (!value || value.length === 0) continue;
 
+                let isFound = false;
+
                 if (Array.isArray(contactAttributes[key])) {
                     for (const attribute of contactAttributes[key]) {
                         if (value.includes(attribute)) {
+                            isFound = true;
                             break;
                         }
                     }
-                    continue;
+                    if (isFound) {
+                        continue;
+                    }
                 } else if (value.includes(contactAttributes[key])) {
                     continue;
                 }


### PR DESCRIPTION
- Add demo contact attribute (branch) allowing to select multiple fields.
- Add demo filter for branch for testing.

Logic for assigning contacts to filters:
- If multiple filter are set in a target group, the contact has to have all those attributes. (e.g. SALUTATION: "Female", BRANCH: "Marketing" -> contact needs both attributes to be assigned.
- If a filter value is an array, one matching  value is required for assigning a contact. (e.g. BRANCH: ["Marketing", "Products"] -> contact only needs one of the values.

Contact Attributes:
![Screenshot 2024-09-20 at 09 31 48](https://github.com/user-attachments/assets/cf3ab1ea-062b-4b62-9820-9088e80a5766)


Filter:
<img width="1637" alt="Screenshot 2024-09-25 at 09 36 38" src="https://github.com/user-attachments/assets/0fc6ac65-fe44-4cd3-a4c9-8e995b704df4">
