### PR TITLE
Fix i18n and lang repo handling

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -1,67 +1,74 @@
 name: i18n
 
 on:
-    push:
-        branches:
-            - main
+  push:
+    branches:
+      - main
 
 jobs:
-    i18n:
-        runs-on: ubuntu-latest
-        steps:
-            - run: echo "${{ github.actor }}"
+  i18n:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ github.actor }}"
 
-            - uses: actions/checkout@v3
-              with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
-            - run: |
-                  git config user.name github-actions
-                  git config user.email github-actions@github.com
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
 
-            - name: "Library: Clone translations"
-              uses: actions/checkout@v3
-              with:
-                  repository: vivid-planet/comet-brevo-module-lang
-                  token: ${{ secrets.VIVID_PLANET_BOT_TOKEN }}
-                  path: "demo/admin/lang/comet-brevo-module-lang"
+      - name: "COMET Library: Clone translations"
+        uses: actions/checkout@v3
+        with:
+          repository: vivid-planet/comet-lang
+          token: ${{ secrets.VIVID_PLANET_BOT_TOKEN }}
+          path: "demo/admin/lang/comet-lang"
 
-            - name: "Demo: Clone translations"
-              uses: actions/checkout@v3
-              with:
-                  repository: vivid-planet/comet-brevo-module-demo-lang
-                  token: ${{ secrets.VIVID_PLANET_BOT_TOKEN }}
-                  path: "demo/admin/lang/comet-brevo-module-demo-lang"
+      - name: "COMET Brevo Library: Clone translations"
+        uses: actions/checkout@v3
+        with:
+          repository: vivid-planet/comet-brevo-module-lang
+          token: ${{ secrets.VIVID_PLANET_BOT_TOKEN }}
+          path: "demo/admin/lang/comet-brevo-module-lang"
 
-            - uses: pnpm/action-setup@v2
-              with:
-                  version: 8
+      - name: "Demo: Clone translations"
+        uses: actions/checkout@v3
+        with:
+          repository: vivid-planet/comet-brevo-module-demo-lang
+          token: ${{ secrets.VIVID_PLANET_BOT_TOKEN }}
+          path: "demo/admin/lang/comet-brevo-module-demo-lang"
 
-            - name: Use Node.js 18.x
-              uses: actions/setup-node@v3
-              with:
-                  node-version: 18
-                  registry-url: "https://registry.npmjs.org"
-                  cache: "pnpm" # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
 
-            - run: pnpm install --frozen-lockfile
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: "https://registry.npmjs.org"
+          cache: "pnpm" # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
 
-            - name: "Library: Extract i18n strings"
-              run: |
-                  pnpm run intl:extract
-                  cp -r lang/* demo/admin/lang/comet-brevo-module-lang/
+      - run: pnpm install --frozen-lockfile
 
-            - name: "Library: Update translateable strings"
-              uses: EndBug/add-and-commit@v9
-              with:
-                  cwd: "./demo/admin/lang/comet-brevo-module-lang"
+      - name: "Library: Extract i18n strings"
+        run: |
+          pnpm run intl:extract
+          cp -r lang/* demo/admin/lang/comet-brevo-module-lang/
 
-            - name: "Demo: Extract i18n strings"
-              run: |
-                  cd demo/admin
-                  pnpm run intl:extract
-                  cp -r lang-extracted/* lang/comet-brevo-module-demo-lang
+      - name: "Library: Update translateable strings"
+        uses: EndBug/add-and-commit@v9
+        with:
+          cwd: "./demo/admin/lang/comet-brevo-module-lang"
 
-            - name: "Demo: Update translateable strings"
-              uses: EndBug/add-and-commit@v9
-              with:
-                  cwd: "./demo/admin/lang/comet-brevo-module-demo-lang"
+      - name: "Demo: Extract i18n strings"
+        run: |
+          cd demo/admin
+          pnpm run intl:extract
+          cp -r lang-extracted/* lang/comet-brevo-module-demo-lang
+
+      - name: "Demo: Update translateable strings"
+        uses: EndBug/add-and-commit@v9
+        with:
+          cwd: "./demo/admin/lang/comet-brevo-module-demo-lang"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,66 +1,72 @@
 name: Lint
 
 on:
-    pull_request:
-        types:
-            - opened
-            - synchronize
-            - reopened
-    push:
-        branches:
-            - main
-            - next
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  push:
+    branches:
+      - main
+      - next
 
 jobs:
-    lint:
-        name: Lint
-        runs-on: ubuntu-latest
-        steps:
-            - run: echo "${{ github.actor }}"
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "${{ github.actor }}"
 
-            - uses: actions/checkout@v3
-              with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
-            - run: |
-                  git config user.name github-actions
-                  git config user.email github-actions@github.com
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
 
-            - name: "Library: Clone translations"
-              uses: actions/checkout@v3
-              with:
-                  repository: vivid-planet/comet-brevo-module-lang
-                  token: ${{ secrets.GITHUB_TOKEN }}
-                  path: "demo/admin/lang/comet-brevo-module-lang"
+      - name: "COMET Library: Clone translations"
+        uses: actions/checkout@v3
+        with:
+          repository: vivid-planet/comet-lang
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: "demo/admin/lang/comet-lang"
 
-            - name: "Demo: Clone translations"
-              uses: actions/checkout@v3
-              with:
-                  repository: vivid-planet/comet-brevo-module-demo-lang
-                  token: ${{ secrets.GITHUB_TOKEN }}
-                  path: "demo/admin/lang/comet-brevo-module-demo-lang"
+      - name: "COMET Brevo Library: Clone translations"
+        uses: actions/checkout@v3
+        with:
+          repository: vivid-planet/comet-brevo-module-lang
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: "demo/admin/lang/comet-brevo-module-lang"
 
-            - uses: pnpm/action-setup@v2
-              with:
-                  version: 8
+      - name: "Demo: Clone translations"
+        uses: actions/checkout@v3
+        with:
+          repository: vivid-planet/comet-brevo-module-demo-lang
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: "demo/admin/lang/comet-brevo-module-demo-lang"
 
-            - name: Use Node.js 18.x
-              uses: actions/setup-node@v3
-              with:
-                  node-version: 18
-                  registry-url: "https://registry.npmjs.org"
-                  cache: "pnpm" # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
 
-            - run: pnpm install --frozen-lockfile
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: "https://registry.npmjs.org"
+          cache: "pnpm" # https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-dependencies
 
-            - name: Copy schema files
-              run: pnpm run copy-schema-files
+      - run: pnpm install --frozen-lockfile
 
-            - name: Build
-              run: pnpm run build:lib
+      - name: Copy schema files
+        run: pnpm run copy-schema-files
 
-            - name: Lint
-              run: |
-                  pnpm exec prettier --check "./*.{js,json,md,yml}"
-                  pnpm run lint
-                  # check for duplicate ids of formatted messages
-                  pnpm run intl:extract
+      - name: Build
+        run: pnpm run build:lib
+
+      - name: Lint
+        run: |
+          pnpm run lint
+          # check for duplicate ids of formatted messages
+          pnpm run intl:extract

--- a/demo/admin/intl-update.sh
+++ b/demo/admin/intl-update.sh
@@ -7,3 +7,4 @@ mkdir -p ./lang
 
 git clone https://github.com/vivid-planet/comet-brevo-module-demo-lang lang/comet-brevo-module-demo-lang
 git clone https://github.com/vivid-planet/comet-brevo-module-lang.git lang/comet-brevo-module-lang
+git clone https://github.com/vivid-planet/comet-lang.git lang/comet-lang

--- a/demo/admin/package.json
+++ b/demo/admin/package.json
@@ -13,6 +13,7 @@
         "lint:eslint": "eslint --max-warnings 0 --ext .ts,.tsx,.js,.jsx,.json,.md src/ package.json",
         "lint:tsc": "tsc --project .",
         "intl:extract": "formatjs extract \"src/**/*.ts*\" --ignore ./**.d.ts --out-file lang-extracted/en.json --format simple",
+        "intl:compile:comet-brevo-module": "formatjs compile-folder --format simple --ast lang/comet-brevo-module-lang lang-compiled/comet-brevo-module-lang",
         "intl:compile:comet-brevo-module-demo": "formatjs compile-folder --format simple --ast lang/comet-brevo-module-demo-lang/admin lang-compiled/comet-brevo-module-demo-lang",
         "intl:compile:comet": "formatjs compile-folder --format simple --ast lang/comet-lang lang-compiled/comet-lang",
         "intl:compile": "run-p intl:compile:comet intl:compile:comet-brevo-module-demo intl:compile:comet-brevo-module",

--- a/demo/admin/package.json
+++ b/demo/admin/package.json
@@ -13,9 +13,9 @@
         "lint:eslint": "eslint --max-warnings 0 --ext .ts,.tsx,.js,.jsx,.json,.md src/ package.json",
         "lint:tsc": "tsc --project .",
         "intl:extract": "formatjs extract \"src/**/*.ts*\" --ignore ./**.d.ts --out-file lang-extracted/en.json --format simple",
-        "intl:compile:comet-brevo-module": "formatjs compile-folder --format simple --ast lang/comet-brevo-module-lang lang-compiled/comet-brevo-module-lang",
-        "intl:compile:comet-brevo-module-demo": "formatjs compile-folder --format simple --ast lang/comet-brevo-module-demo-lang lang-compiled/comet-brevo-module-demo-lang",
-        "intl:compile": "run-p intl:compile:comet-brevo-module-demo intl:compile:comet-brevo-module",
+        "intl:compile:comet-brevo-module-demo": "formatjs compile-folder --format simple --ast lang/comet-brevo-module-demo-lang/admin lang-compiled/comet-brevo-module-demo-lang",
+        "intl:compile:comet": "formatjs compile-folder --format simple --ast lang/comet-lang lang-compiled/comet-lang",
+        "intl:compile": "run-p intl:compile:comet intl:compile:comet-brevo-module-demo intl:compile:comet-brevo-module",
         "generate-block-types": "comet generate-block-types --inputs",
         "generate-block-types:watch": "chokidar -s \"**/block-meta.json\" -c \"npm run generate-block-types\""
     },

--- a/demo/admin/src/lang.ts
+++ b/demo/admin/src/lang.ts
@@ -2,12 +2,19 @@ import { ResolvedIntlConfig } from "react-intl";
 
 import project_messages_de from "../lang-compiled/comet-brevo-module-demo-lang/de.json";
 import project_messages_en from "../lang-compiled/comet-brevo-module-demo-lang/en.json";
-import comet_messages_de from "../lang-compiled/comet-brevo-module-lang/de.json";
-import comet_messages_en from "../lang-compiled/comet-brevo-module-lang/en.json";
+import comet_brevo_module_messages_de from "../lang-compiled/comet-brevo-module-lang/de.json";
+import comet_brevo_module_messages_en from "../lang-compiled/comet-brevo-module-lang/en.json";
+import comet_messages_de from "../lang-compiled/comet-lang/de.json";
+import comet_messages_en from "../lang-compiled/comet-lang/en.json";
 
 const cometMessages = {
     en: comet_messages_en,
     de: comet_messages_de,
+};
+
+const cometBrevoModuleMessages = {
+    en: comet_brevo_module_messages_en,
+    de: comet_brevo_module_messages_de,
 };
 
 const projectMessages = {
@@ -18,6 +25,7 @@ const projectMessages = {
 export const getMessages = (): ResolvedIntlConfig["messages"] => {
     return {
         ...cometMessages["en"],
+        ...cometBrevoModuleMessages["en"],
         ...projectMessages["en"],
     };
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "lint": "pnpm recursive run lint",
         "lint:eslint": "pnpm recursive run lint:eslint",
         "lint:tsc": "pnpm recursive run lint:tsc",
-        "intl:extract": "formatjs extract \"src/**/*.ts*\" --ignore ./**.d.ts --out-file lang-extracted/en.json --format simple",
+        "intl:extract": "formatjs extract './packages/admin/**/*.ts*' --out-file 'lang/en.json' --ignore './**.d.ts' --ignore './**.d.ts.map' --format simple --throws",
         "version": "$npm_execpath changeset version && pnpm install --lockfile-only",
         "publish": "pnpm run build:lib && $npm_execpath changeset publish"
     },


### PR DESCRIPTION
The i18n Pipeline always failed, there were changes necessary in the lang repo.
The changed where made in the main branch but forgotten in the v1.x.x branch

it's a combination of these PR's:
 - https://github.com/vivid-planet/comet-brevo-module/pull/75
 - https://github.com/vivid-planet/comet-brevo-module/pull/76