### PR TITLE
COM-1135: Improve Brevo Error Messages

### DIFF
--- a/.changeset/little-cougars-melt.md
+++ b/.changeset/little-cougars-melt.md
@@ -1,0 +1,5 @@
+---
+"@comet/brevo-api": patch
+---
+
+Handle brevo errors explicitly to improve error messages

--- a/packages/api/src/brevo-api/brevo-api-campaigns.service.ts
+++ b/packages/api/src/brevo-api/brevo-api-campaigns.service.ts
@@ -7,6 +7,7 @@ import { BrevoModuleConfig } from "../config/brevo-module.config";
 import { BREVO_MODULE_CONFIG } from "../config/brevo-module.constants";
 import { EmailCampaignInterface } from "../email-campaign/entities/email-campaign-entity.factory";
 import { SendingState } from "../email-campaign/sending-state.enum";
+import { handleBrevoError } from "./brevo-api.utils";
 import { BrevoApiCampaign } from "./dto/brevo-api-campaign";
 import { BrevoApiCampaignStatistics } from "./dto/brevo-api-campaign-statistics";
 
@@ -17,32 +18,40 @@ export class BrevoApiCampaignsService {
     constructor(@Inject(BREVO_MODULE_CONFIG) private readonly config: BrevoModuleConfig, @Inject(CACHE_MANAGER) private cacheManager: Cache) {}
 
     private getCampaignsApi(scope: EmailCampaignScopeInterface): Brevo.EmailCampaignsApi {
-        const existingCampaignsApiForScope = this.campaignsApis.get(JSON.stringify(scope));
+        try {
+            const existingCampaignsApiForScope = this.campaignsApis.get(JSON.stringify(scope));
 
-        if (existingCampaignsApiForScope) {
-            return existingCampaignsApiForScope;
+            if (existingCampaignsApiForScope) {
+                return existingCampaignsApiForScope;
+            }
+
+            const { apiKey } = this.config.brevo.resolveConfig(scope);
+            const campaignsApi = new Brevo.EmailCampaignsApi();
+            campaignsApi.setApiKey(Brevo.EmailCampaignsApiApiKeys.apiKey, apiKey);
+
+            this.campaignsApis.set(JSON.stringify(scope), campaignsApi);
+
+            return campaignsApi;
+        } catch (error) {
+            handleBrevoError(error);
         }
-
-        const { apiKey } = this.config.brevo.resolveConfig(scope);
-        const campaignsApi = new Brevo.EmailCampaignsApi();
-        campaignsApi.setApiKey(Brevo.EmailCampaignsApiApiKeys.apiKey, apiKey);
-
-        this.campaignsApis.set(JSON.stringify(scope), campaignsApi);
-
-        return campaignsApi;
     }
 
     public getSendingInformationFromBrevoCampaign(campaign: BrevoApiCampaign): SendingState {
-        if (campaign.status === Brevo.GetEmailCampaignsCampaignsInner.StatusEnum.Sent) {
-            return SendingState.SENT;
-        } else if (
-            campaign.status === Brevo.GetEmailCampaignsCampaignsInner.StatusEnum.Queued ||
-            campaign.status === Brevo.GetEmailCampaignsCampaignsInner.StatusEnum.InProcess
-        ) {
-            return SendingState.SCHEDULED;
-        }
+        try {
+            if (campaign.status === Brevo.GetEmailCampaignsCampaignsInner.StatusEnum.Sent) {
+                return SendingState.SENT;
+            } else if (
+                campaign.status === Brevo.GetEmailCampaignsCampaignsInner.StatusEnum.Queued ||
+                campaign.status === Brevo.GetEmailCampaignsCampaignsInner.StatusEnum.InProcess
+            ) {
+                return SendingState.SCHEDULED;
+            }
 
-        return SendingState.DRAFT;
+            return SendingState.DRAFT;
+        } catch (error) {
+            handleBrevoError(error);
+        }
     }
 
     public async createBrevoCampaign({
@@ -54,20 +63,24 @@ export class BrevoApiCampaignsService {
         htmlContent: string;
         scheduledAt?: Date;
     }): Promise<number> {
-        const targetGroups = await campaign.targetGroups.loadItems();
-        const { sender } = this.config.brevo.resolveConfig(campaign.scope);
+        try {
+            const targetGroups = await campaign.targetGroups.loadItems();
+            const { sender } = this.config.brevo.resolveConfig(campaign.scope);
 
-        const emailCampaign = {
-            name: campaign.title,
-            subject: campaign.subject,
-            sender: { name: sender.name, email: sender.email },
-            recipients: { listIds: targetGroups.map((targetGroup) => targetGroup.brevoId) },
-            htmlContent,
-            scheduledAt: scheduledAt?.toISOString(),
-        };
+            const emailCampaign = {
+                name: campaign.title,
+                subject: campaign.subject,
+                sender: { name: sender.name, email: sender.email },
+                recipients: { listIds: targetGroups.map((targetGroup) => targetGroup.brevoId) },
+                htmlContent,
+                scheduledAt: scheduledAt?.toISOString(),
+            };
 
-        const data = await this.getCampaignsApi(campaign.scope).createEmailCampaign(emailCampaign);
-        return data.body.id;
+            const data = await this.getCampaignsApi(campaign.scope).createEmailCampaign(emailCampaign);
+            return data.body.id;
+        } catch (error) {
+            handleBrevoError(error);
+        }
     }
 
     public async updateBrevoCampaign({
@@ -81,96 +94,124 @@ export class BrevoApiCampaignsService {
         htmlContent: string;
         scheduledAt?: Date;
     }): Promise<boolean> {
-        const targetGroups = await campaign.targetGroups.loadItems();
-        const { sender } = this.config.brevo.resolveConfig(campaign.scope);
+        try {
+            const targetGroups = await campaign.targetGroups.loadItems();
+            const { sender } = this.config.brevo.resolveConfig(campaign.scope);
 
-        const emailCampaign = {
-            name: campaign.title,
-            subject: campaign.subject,
-            sender: { name: sender.name, mail: sender.email },
-            recipients: { listIds: targetGroups.map((targetGroup) => targetGroup.brevoId) },
-            htmlContent,
-            scheduledAt: scheduledAt?.toISOString(),
-        };
+            const emailCampaign = {
+                name: campaign.title,
+                subject: campaign.subject,
+                sender: { name: sender.name, mail: sender.email },
+                recipients: { listIds: targetGroups.map((targetGroup) => targetGroup.brevoId) },
+                htmlContent,
+                scheduledAt: scheduledAt?.toISOString(),
+            };
 
-        const result = await this.getCampaignsApi(campaign.scope).updateEmailCampaign(id, emailCampaign);
-        return result.response.statusCode === 204;
+            const result = await this.getCampaignsApi(campaign.scope).updateEmailCampaign(id, emailCampaign);
+            return result.response.statusCode === 204;
+        } catch (error) {
+            handleBrevoError(error);
+        }
     }
 
     public async sendBrevoCampaign(campaign: EmailCampaignInterface): Promise<boolean> {
-        if (!campaign.brevoId) {
-            throw new Error("Campaign has no brevoId");
-        }
+        try {
+            if (!campaign.brevoId) {
+                throw new Error("Campaign has no brevoId");
+            }
 
-        const result = await this.getCampaignsApi(campaign.scope).sendEmailCampaignNow(campaign.brevoId);
-        return result.response.statusCode === 204;
+            const result = await this.getCampaignsApi(campaign.scope).sendEmailCampaignNow(campaign.brevoId);
+            return result.response.statusCode === 204;
+        } catch (error) {
+            handleBrevoError(error);
+        }
     }
 
     public async updateBrevoCampaignStatus(campaign: EmailCampaignInterface, updatedStatus: Brevo.UpdateCampaignStatus.StatusEnum): Promise<boolean> {
-        if (!campaign.brevoId) {
-            throw new Error("Campaign has no brevoId");
-        }
+        try {
+            if (!campaign.brevoId) {
+                throw new Error("Campaign has no brevoId");
+            }
 
-        const status = new Brevo.UpdateCampaignStatus();
-        status.status = updatedStatus;
-        const result = await this.getCampaignsApi(campaign.scope).updateCampaignStatus(campaign.brevoId, status);
-        return result.response.statusCode === 204;
+            const status = new Brevo.UpdateCampaignStatus();
+            status.status = updatedStatus;
+            const result = await this.getCampaignsApi(campaign.scope).updateCampaignStatus(campaign.brevoId, status);
+            return result.response.statusCode === 204;
+        } catch (error) {
+            handleBrevoError(error);
+        }
     }
 
     public async sendTestEmail(campaign: EmailCampaignInterface, emails: string[]): Promise<boolean> {
-        if (!campaign.brevoId) {
-            throw new Error("Campaign has no brevoId");
-        }
+        try {
+            if (!campaign.brevoId) {
+                throw new Error("Campaign has no brevoId");
+            }
 
-        const result = await this.getCampaignsApi(campaign.scope).sendTestEmail(campaign.brevoId, { emailTo: emails });
-        return result.response.statusCode === 204;
+            const result = await this.getCampaignsApi(campaign.scope).sendTestEmail(campaign.brevoId, { emailTo: emails });
+            return result.response.statusCode === 204;
+        } catch (error) {
+            handleBrevoError(error);
+        }
     }
 
     public async loadBrevoCampaignsByIds(ids: number[], scope: EmailCampaignScopeInterface): Promise<BrevoApiCampaign[]> {
-        const brevoCampaigns = [];
-        const nonCachedIds = [];
+        try {
+            const brevoCampaigns = [];
+            const nonCachedIds = [];
 
-        for (const brevoId of ids) {
-            const cachedCampaign: BrevoApiCampaign | undefined = await this.cacheManager.get(`brevo-campaign-${brevoId}`);
-            if (cachedCampaign) {
-                brevoCampaigns.push(cachedCampaign);
-            } else {
-                nonCachedIds.push(brevoId);
+            for (const brevoId of ids) {
+                const cachedCampaign: BrevoApiCampaign | undefined = await this.cacheManager.get(`brevo-campaign-${brevoId}`);
+                if (cachedCampaign) {
+                    brevoCampaigns.push(cachedCampaign);
+                } else {
+                    nonCachedIds.push(brevoId);
+                }
             }
-        }
 
-        for await (const campaign of this.getCampaignsResponse(nonCachedIds, scope)) {
-            brevoCampaigns.push(campaign);
-            await this.cacheManager.set(`brevo-campaign-${campaign.id}`, campaign);
-        }
+            for await (const campaign of this.getCampaignsResponse(nonCachedIds, scope)) {
+                brevoCampaigns.push(campaign);
+                await this.cacheManager.set(`brevo-campaign-${campaign.id}`, campaign);
+            }
 
-        return brevoCampaigns;
+            return brevoCampaigns;
+        } catch (error) {
+            handleBrevoError(error);
+        }
     }
 
     public async loadBrevoCampaignById(campaign: EmailCampaignInterface): Promise<BrevoApiCampaign> {
-        const brevoId = campaign.brevoId;
-        if (brevoId == undefined) {
-            throw new Error("Campaign has no brevoId");
+        try {
+            const brevoId = campaign.brevoId;
+            if (brevoId == undefined) {
+                throw new Error("Campaign has no brevoId");
+            }
+
+            return this.cacheManager.wrap<BrevoApiCampaign>(`brevo-campaign-${campaign.id}`, async () => {
+                const response = await this.getCampaignsApi(campaign.scope).getEmailCampaign(brevoId);
+
+                return response.body;
+            });
+        } catch (error) {
+            handleBrevoError(error);
         }
-
-        return this.cacheManager.wrap<BrevoApiCampaign>(`brevo-campaign-${campaign.id}`, async () => {
-            const response = await this.getCampaignsApi(campaign.scope).getEmailCampaign(brevoId);
-
-            return response.body;
-        });
     }
 
     public async loadBrevoCampaignStatisticsById(campaign: EmailCampaignInterface): Promise<BrevoApiCampaignStatistics> {
-        if (!campaign.brevoId) {
-            throw new Error("Campaign has no brevoId");
+        try {
+            if (!campaign.brevoId) {
+                throw new Error("Campaign has no brevoId");
+            }
+
+            const brevoCampaign = await this.loadBrevoCampaignById(campaign);
+
+            // The property globalStats seems to be right here according to the docs: https://developers.brevo.com/reference/getemailcampaign
+            // Unforunately, the API returns only 0 values for the globalStats property.
+            // That's why we return the first element of the campaignStats array, which contains the correct values.
+            return brevoCampaign.statistics.campaignStats[0];
+        } catch (error) {
+            handleBrevoError(error);
         }
-
-        const brevoCampaign = await this.loadBrevoCampaignById(campaign);
-
-        // The property globalStats seems to be right here according to the docs: https://developers.brevo.com/reference/getemailcampaign
-        // Unforunately, the API returns only 0 values for the globalStats property.
-        // That's why we return the first element of the campaignStats array, which contains the correct values.
-        return brevoCampaign.statistics.campaignStats[0];
     }
 
     private async *getCampaignsResponse(
@@ -182,23 +223,27 @@ export class BrevoApiCampaignsService {
         const limit = 100;
 
         while (true) {
-            const campaignsResponse = await this.getCampaignsApi(scope).getEmailCampaigns(
-                undefined,
-                status,
-                undefined,
-                undefined,
-                undefined,
-                limit,
-                offset,
-            );
-            const campaignArray = (campaignsResponse.body.campaigns ?? []).filter((item) => ids.includes(item.id));
+            try {
+                const campaignsResponse = await this.getCampaignsApi(scope).getEmailCampaigns(
+                    undefined,
+                    status,
+                    undefined,
+                    undefined,
+                    undefined,
+                    limit,
+                    offset,
+                );
+                const campaignArray = (campaignsResponse.body.campaigns ?? []).filter((item) => ids.includes(item.id));
 
-            if (campaignArray.length === 0) {
-                break;
+                if (campaignArray.length === 0) {
+                    break;
+                }
+                yield* campaignArray;
+
+                offset += limit;
+            } catch (error) {
+                handleBrevoError(error);
             }
-            yield* campaignArray;
-
-            offset += limit;
         }
     }
 }

--- a/packages/api/src/brevo-api/brevo-api-contact.service.ts
+++ b/packages/api/src/brevo-api/brevo-api-contact.service.ts
@@ -5,7 +5,7 @@ import { BrevoContactAttributesInterface, EmailCampaignScopeInterface } from "sr
 import { BrevoContactInterface } from "../brevo-contact/dto/brevo-contact.factory";
 import { BrevoModuleConfig } from "../config/brevo-module.config";
 import { BREVO_MODULE_CONFIG } from "../config/brevo-module.constants";
-import { isErrorFromBrevo } from "./brevo-api.utils";
+import { handleBrevoError, isErrorFromBrevo } from "./brevo-api.utils";
 import { BrevoApiContactList } from "./dto/brevo-api-contact-list";
 
 export interface CreateDoubleOptInContactData {
@@ -21,19 +21,23 @@ export class BrevoApiContactsService {
     constructor(@Inject(BREVO_MODULE_CONFIG) private readonly config: BrevoModuleConfig) {}
 
     private getContactsApi(scope: EmailCampaignScopeInterface): Brevo.ContactsApi {
-        const existingContactsApiForScope = this.contactsApis.get(JSON.stringify(scope));
+        try {
+            const existingContactsApiForScope = this.contactsApis.get(JSON.stringify(scope));
 
-        if (existingContactsApiForScope) {
-            return existingContactsApiForScope;
+            if (existingContactsApiForScope) {
+                return existingContactsApiForScope;
+            }
+
+            const { apiKey } = this.config.brevo.resolveConfig(scope);
+            const contactsApi = new Brevo.ContactsApi();
+            contactsApi.setApiKey(Brevo.ContactsApiApiKeys.apiKey, apiKey);
+
+            this.contactsApis.set(JSON.stringify(scope), contactsApi);
+
+            return contactsApi;
+        } catch (error) {
+            handleBrevoError(error);
         }
-
-        const { apiKey } = this.config.brevo.resolveConfig(scope);
-        const contactsApi = new Brevo.ContactsApi();
-        contactsApi.setApiKey(Brevo.ContactsApiApiKeys.apiKey, apiKey);
-
-        this.contactsApis.set(JSON.stringify(scope), contactsApi);
-
-        return contactsApi;
     }
 
     public async createDoubleOptInBrevoContact(
@@ -42,16 +46,20 @@ export class BrevoApiContactsService {
         templateId: number,
         scope: EmailCampaignScopeInterface,
     ): Promise<boolean> {
-        const contact = {
-            email,
-            includeListIds: brevoIds,
-            templateId,
-            redirectionUrl,
-            attributes,
-        };
-        const { response } = await this.getContactsApi(scope).createDoiContact(contact);
+        try {
+            const contact = {
+                email,
+                includeListIds: brevoIds,
+                templateId,
+                redirectionUrl,
+                attributes,
+            };
+            const { response } = await this.getContactsApi(scope).createDoiContact(contact);
 
-        return response.statusCode === 204 || response.statusCode === 201;
+            return response.statusCode === 204 || response.statusCode === 201;
+        } catch (error) {
+            handleBrevoError(error);
+        }
     }
 
     public async updateContact(
@@ -64,28 +72,44 @@ export class BrevoApiContactsService {
         }: { blocked?: boolean; attributes?: BrevoContactAttributesInterface; listIds?: number[]; unlinkListIds?: number[] },
         scope: EmailCampaignScopeInterface,
     ): Promise<BrevoContactInterface> {
-        const idAsString = id.toString(); // brevo expects a string, because it can be an email or the id, so we have to transform the id to string
-        await this.getContactsApi(scope).updateContact(idAsString, { emailBlacklisted: blocked, attributes, listIds, unlinkListIds });
-        return this.findContact(id, scope);
+        try {
+            const idAsString = id.toString(); // brevo expects a string, because it can be an email or the id, so we have to transform the id to string
+            await this.getContactsApi(scope).updateContact(idAsString, { emailBlacklisted: blocked, attributes, listIds, unlinkListIds });
+            return this.findContact(id, scope);
+        } catch (error) {
+            handleBrevoError(error);
+        }
     }
 
     public async updateMultipleContacts(contacts: Brevo.UpdateBatchContactsContactsInner[], scope: EmailCampaignScopeInterface): Promise<boolean> {
-        const { response } = await this.getContactsApi(scope).updateBatchContacts({ contacts });
-        return response.statusCode === 204;
+        try {
+            const { response } = await this.getContactsApi(scope).updateBatchContacts({ contacts });
+            return response.statusCode === 204;
+        } catch (error) {
+            handleBrevoError(error);
+        }
     }
 
     public async deleteContact(id: number, scope: EmailCampaignScopeInterface): Promise<boolean> {
-        const idAsString = id.toString(); // brevo expects a string, because it can be an email or the id, so we have to transform the id to string
-        const { response } = await this.getContactsApi(scope).deleteContact(idAsString);
+        try {
+            const idAsString = id.toString(); // brevo expects a string, because it can be an email or the id, so we have to transform the id to string
+            const { response } = await this.getContactsApi(scope).deleteContact(idAsString);
 
-        return response.statusCode === 204;
+            return response.statusCode === 204;
+        } catch (error) {
+            handleBrevoError(error);
+        }
     }
 
     public async findContact(idOrEmail: string | number, scope: EmailCampaignScopeInterface): Promise<BrevoContactInterface> {
-        const idAsString = String(idOrEmail); // brevo expects a string, because it can be an email or the id
-        const { body } = await this.getContactsApi(scope).getContactInfo(idAsString);
+        try {
+            const idAsString = String(idOrEmail); // brevo expects a string, because it can be an email or the id
+            const { body } = await this.getContactsApi(scope).getContactInfo(idAsString);
 
-        return body;
+            return body;
+        } catch (error) {
+            handleBrevoError(error);
+        }
     }
 
     public async getContactInfoByEmail(email: string, scope: EmailCampaignScopeInterface): Promise<BrevoContactInterface | undefined> {
@@ -99,7 +123,7 @@ export class BrevoApiContactsService {
             if (isErrorFromBrevo(error) && (error.response.statusCode === 404 || error.response.statusCode === 400)) {
                 return undefined;
             }
-            throw error;
+            handleBrevoError(error);
         }
     }
 
@@ -109,26 +133,38 @@ export class BrevoApiContactsService {
         offset: number,
         scope: EmailCampaignScopeInterface,
     ): Promise<[BrevoContactInterface[], number]> {
-        const data = await this.getContactsApi(scope).getContactsFromList(id, undefined, limit, offset);
+        try {
+            const data = await this.getContactsApi(scope).getContactsFromList(id, undefined, limit, offset);
 
-        return [data.body.contacts, data.body.count];
+            return [data.body.contacts, data.body.count];
+        } catch (error) {
+            handleBrevoError(error);
+        }
     }
 
     public async findContacts(limit: number, offset: number, scope: EmailCampaignScopeInterface): Promise<BrevoContactInterface[]> {
-        const data = await this.getContactsApi(scope).getContacts(limit, offset);
+        try {
+            const data = await this.getContactsApi(scope).getContacts(limit, offset);
 
-        return data.body.contacts;
+            return data.body.contacts;
+        } catch (error) {
+            handleBrevoError(error);
+        }
     }
 
     public async deleteContacts(contacts: BrevoContactInterface[], scope: EmailCampaignScopeInterface): Promise<boolean> {
-        for (const contact of contacts) {
-            const idAsString = contact.id.toString();
-            const response = await this.getContactsApi(scope).deleteContact(idAsString);
-            if (response.response.statusCode !== 204) {
-                return false;
+        try {
+            for (const contact of contacts) {
+                const idAsString = contact.id.toString();
+                const response = await this.getContactsApi(scope).deleteContact(idAsString);
+                if (response.response.statusCode !== 204) {
+                    return false;
+                }
             }
+            return true;
+        } catch (error) {
+            handleBrevoError(error);
         }
-        return true;
     }
 
     public async blacklistMultipleContacts(emails: string[], scope: EmailCampaignScopeInterface): Promise<void> {
@@ -138,39 +174,58 @@ export class BrevoApiContactsService {
     }
 
     public async createBrevoContactList(title: string, scope: EmailCampaignScopeInterface): Promise<number | undefined> {
-        const contactList = {
-            name: title,
-            folderId: 1, // folderId is required, folder #1 is created by default
-        };
+        try {
+            const contactList = {
+                name: title,
+                folderId: 1, // folderId is required, folder #1 is created by default
+            };
 
-        const data = await this.getContactsApi(scope).createList(contactList);
-        return data.body.id;
+            const data = await this.getContactsApi(scope).createList(contactList);
+            return data.body.id;
+        } catch (error) {
+            handleBrevoError(error);
+        }
     }
 
     public async updateBrevoContactList(id: number, title: string, scope: EmailCampaignScopeInterface): Promise<boolean> {
-        const data = await this.getContactsApi(scope).updateList(id, { name: title });
-        return data.response.statusCode === 204;
+        try {
+            const data = await this.getContactsApi(scope).updateList(id, { name: title });
+            return data.response.statusCode === 204;
+        } catch (error) {
+            handleBrevoError(error);
+        }
     }
 
     public async deleteBrevoContactList(id: number, scope: EmailCampaignScopeInterface): Promise<boolean> {
-        const data = await this.getContactsApi(scope).deleteList(id);
-        return data.response.statusCode === 204;
+        try {
+            const data = await this.getContactsApi(scope).deleteList(id);
+            return data.response.statusCode === 204;
+        } catch (error) {
+            handleBrevoError(error);
+        }
     }
 
     public async findBrevoContactListById(id: number, scope: EmailCampaignScopeInterface): Promise<BrevoApiContactList> {
-        const data = await this.getContactsApi(scope).getList(id);
-        return data.body;
+        try {
+            const data = await this.getContactsApi(scope).getList(id);
+            return data.body;
+        } catch (error) {
+            handleBrevoError(error);
+        }
     }
 
     public async findBrevoContactListsByIds(ids: number[], scope: EmailCampaignScopeInterface): Promise<BrevoApiContactList[]> {
-        const lists: BrevoApiContactList[] = [];
-        for await (const list of await this.getBrevoContactListResponses(scope)) {
-            if (ids.includes(list.id)) {
-                lists.push(list);
+        try {
+            const lists: BrevoApiContactList[] = [];
+            for await (const list of await this.getBrevoContactListResponses(scope)) {
+                if (ids.includes(list.id)) {
+                    lists.push(list);
+                }
             }
+            return lists;
+        } catch (error) {
+            handleBrevoError(error);
         }
-
-        return lists;
     }
 
     async *getBrevoContactListResponses(scope: EmailCampaignScopeInterface): AsyncGenerator<BrevoApiContactList, void, undefined> {
@@ -178,15 +233,19 @@ export class BrevoApiContactsService {
         let offset = 0;
 
         while (true) {
-            const listsResponse = await this.getContactsApi(scope).getLists(limit, offset);
-            const lists = listsResponse.body.lists ?? [];
+            try {
+                const listsResponse = await this.getContactsApi(scope).getLists(limit, offset);
+                const lists = listsResponse.body.lists ?? [];
 
-            if (lists.length === 0) {
-                break;
+                if (lists.length === 0) {
+                    break;
+                }
+                yield* lists;
+
+                offset += limit;
+            } catch (error) {
+                handleBrevoError(error);
             }
-            yield* lists;
-
-            offset += limit;
         }
     }
 }

--- a/packages/api/src/brevo-api/brevo-api.utils.ts
+++ b/packages/api/src/brevo-api/brevo-api.utils.ts
@@ -1,5 +1,26 @@
+import { ErrorModel } from "@getbrevo/brevo";
 import * as http from "http";
 
-export function isErrorFromBrevo(error: unknown): error is { response: http.IncomingMessage } {
-    return typeof error === "object" && error !== null && "response" in error && error.response instanceof http.IncomingMessage;
+export function isErrorFromBrevo(error: unknown): error is { response: http.IncomingMessage; body: ErrorModel } {
+    return (
+        typeof error === "object" &&
+        error !== null &&
+        "response" in error &&
+        error.response instanceof http.IncomingMessage &&
+        "body" in error &&
+        typeof error.body === "object" &&
+        error.body !== null &&
+        "code" in error.body &&
+        typeof error.body.code === "string" &&
+        "message" in error.body &&
+        typeof error.body.message === "string"
+    );
+}
+
+export function handleBrevoError(error: unknown): never {
+    if (isErrorFromBrevo(error)) {
+        throw new Error(error.body.message);
+    } else {
+        throw new Error();
+    }
 }

--- a/packages/api/src/brevo-api/brevo-api.utils.ts
+++ b/packages/api/src/brevo-api/brevo-api.utils.ts
@@ -21,6 +21,6 @@ export function handleBrevoError(error: unknown): never {
     if (isErrorFromBrevo(error)) {
         throw new Error(error.body.message);
     } else {
-        throw new Error();
+        throw error;
     }
 }

--- a/packages/api/src/target-group/target-groups.service.ts
+++ b/packages/api/src/target-group/target-groups.service.ts
@@ -121,7 +121,6 @@ export class TargetGroupsService {
             return true;
         } catch (error) {
             handleBrevoError(error);
-            throw error;
         }
     }
 


### PR DESCRIPTION
Errors from the Brevo API weren't explicitly handled. This error report wasn't helpful and devs would have to view the API logs to understand the actual error. To improve this, we now wrap all Brevo API operations in a try/catch block and handle errors explicitly.


<!--

Everything below this is intended to help ease reviewing this PR.
Remove all unrelated sections.

WHEN MERGING THE PR, REMOVE THIS FROM THE COMMIT MESSAGE.

-->



## Screenshots/screencasts
Example: The entered redirection URL was not a valid URL:
Before:
<img width="935" alt="Screenshot 2024-10-03 at 07 56 01" src="https://github.com/user-attachments/assets/f7e0c225-78c5-49df-8d85-50e4da283dc4">

After:
<img width="926" alt="Screenshot 2024-10-03 at 07 57 21" src="https://github.com/user-attachments/assets/7998edd1-875d-49b8-a1ed-14554e116cfe">


## Changeset

[x] I have verified if my change requires a changeset

## Related tasks and documents

[COM-1135](https://vivid-planet.atlassian.net/browse/COM-1135)



[COM-1135]: https://vivid-planet.atlassian.net/browse/COM-1135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ