### PR TITLE
Remove comment about removing sections from commit message

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,8 +30,6 @@ Your description should include:
 Everything below this is intended to help ease reviewing this PR.
 Remove all unrelated sections.
 
-WHEN MERGING THE PR, REMOVE THIS FROM THE COMMIT MESSAGE.
-
 -->
 
 ## Example


### PR DESCRIPTION
As the pull request description isn't part of the commit message anymore, this comment doesn't make sense anymore.