### PR TITLE
COM-264: Remove axios

### DIFF
--- a/.changeset/seven-icons-smash.md
+++ b/.changeset/seven-icons-smash.md
@@ -1,0 +1,5 @@
+---
+"@comet/brevo-api": patch
+---
+
+Remove peerDependency for axios. It was defined incorrectly and does not have to be a peerDependency.

--- a/.changeset/seven-icons-smash.md
+++ b/.changeset/seven-icons-smash.md
@@ -2,4 +2,4 @@
 "@comet/brevo-api": patch
 ---
 
-Remove peerDependency for axios. It was defined incorrectly and does not have to be a peerDependency.
+Remove peerDependency for axios. Axios is not needed anymore.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -30,6 +30,7 @@
         "@nestjs/axios": "^1.0.0",
         "@nestjs/cache-manager": "^2.2.2",
         "@types/multer": "^1.4.11",
+        "axios": "^0.21.0",
         "cache-manager": "^5.7.3",
         "commander": "^7.2.0",
         "node-fetch": "^2.6.1"
@@ -56,7 +57,6 @@
         "@types/node-fetch": "^2.5.12",
         "@types/rimraf": "^3.0.0",
         "@types/uuid": "^8.3.0",
-        "axios": "^0.21.0",
         "chokidar-cli": "^2.0.0",
         "class-transformer": "^0.5.0",
         "class-validator": "^0.13.1",
@@ -87,7 +87,6 @@
         "@mikro-orm/postgresql": "^5.0.4",
         "@nestjs/common": "^9.0.0",
         "@nestjs/platform-express": "^9.0.0",
-        "axios": "^0.21.0",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.0.0"
     },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -30,7 +30,6 @@
         "@nestjs/axios": "^1.0.0",
         "@nestjs/cache-manager": "^2.2.2",
         "@types/multer": "^1.4.11",
-        "axios": "^0.21.0",
         "cache-manager": "^5.7.3",
         "commander": "^7.2.0",
         "node-fetch": "^2.6.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -952,6 +952,9 @@ importers:
       '@types/multer':
         specifier: ^1.4.11
         version: 1.4.11
+      axios:
+        specifier: ^0.21.0
+        version: 0.21.4
       cache-manager:
         specifier: ^5.7.3
         version: 5.7.3
@@ -1025,9 +1028,6 @@ importers:
       '@types/uuid':
         specifier: ^8.3.0
         version: 8.3.4
-      axios:
-        specifier: ^0.21.0
-        version: 0.21.4
       chokidar-cli:
         specifier: ^2.0.0
         version: 2.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -952,9 +952,6 @@ importers:
       '@types/multer':
         specifier: ^1.4.11
         version: 1.4.11
-      axios:
-        specifier: ^0.21.0
-        version: 0.21.4
       cache-manager:
         specifier: ^5.7.3
         version: 5.7.3


### PR DESCRIPTION
## Description

Axios is not needed anymore. We only use nestjs/axios and there is no installation in the package itself required.