### PR TITLE
Define nestjs/core as peerDependency and types/multer as devDependency

### DIFF
--- a/.changeset/early-deers-sniff.md
+++ b/.changeset/early-deers-sniff.md
@@ -1,0 +1,5 @@
+---
+"@comet/brevo-api": patch
+---
+
+Add `@nestjs/core` as a peer dependency. It should have been included as a peer dependency from the beginning.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -29,7 +29,6 @@
         "@getbrevo/brevo": "^2.2.0",
         "@nestjs/axios": "^1.0.0",
         "@nestjs/cache-manager": "^2.2.2",
-        "@types/multer": "^1.4.11",
         "cache-manager": "^5.7.3",
         "commander": "^7.2.0",
         "node-fetch": "^2.6.1"
@@ -53,6 +52,7 @@
         "@types/jest": "^29.5.0",
         "@types/lodash.isequal": "^4.0.0",
         "@types/mime-db": "^1.43.5",
+        "@types/multer": "^1.4.11",
         "@types/node-fetch": "^2.5.12",
         "@types/rimraf": "^3.0.0",
         "@types/uuid": "^8.3.0",
@@ -85,6 +85,7 @@
         "@mikro-orm/nestjs": "^5.0.0",
         "@mikro-orm/postgresql": "^5.0.4",
         "@nestjs/common": "^9.0.0",
+        "@nestjs/core": "^9.0.0",
         "@nestjs/platform-express": "^9.0.0",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -949,9 +949,6 @@ importers:
       '@nestjs/cache-manager':
         specifier: ^2.2.2
         version: 2.2.2(@nestjs/common@9.4.3)(@nestjs/core@9.4.3)(cache-manager@5.7.3)(rxjs@7.8.1)
-      '@types/multer':
-        specifier: ^1.4.11
-        version: 1.4.11
       cache-manager:
         specifier: ^5.7.3
         version: 5.7.3
@@ -1016,6 +1013,9 @@ importers:
       '@types/mime-db':
         specifier: ^1.43.5
         version: 1.43.5
+      '@types/multer':
+        specifier: ^1.4.11
+        version: 1.4.11
       '@types/node-fetch':
         specifier: ^2.5.12
         version: 2.6.11
@@ -8989,7 +8989,7 @@ packages:
     resolution: {integrity: sha512-svK240gr6LVWvv3YGyhLlA+6LRRWA4mnGIU7RcNmgjBYFl6665wcXrRfxGp5tEPVHUNm5FMcmq7too9bxCwX/w==}
     dependencies:
       '@types/express': 4.17.21
-    dev: false
+    dev: true
 
   /@types/mysql@2.15.22:
     resolution: {integrity: sha512-wK1pzsJVVAjYCSZWQoWHziQZbNggXFDUEIGf54g4ZM/ERuP86uGdWeKZWMYlqTPMZfHJJvLPyogXGvCOg87yLQ==}


### PR DESCRIPTION
COM-264

## Description
 - Nestjs core should be a peerDependency
 - types/multer should be a devDependency

Theoretically a breaking change to add a peerDependency, but since it is a peerDependency of comet/cms-api, the package had to be installed anyway. And comet/cms-api is a peerdependency of this package.
