### PR TITLE
Remove blocked subscribers from target groups query

### DIFF
--- a/.changeset/short-feet-sing.md
+++ b/.changeset/short-feet-sing.md
@@ -1,0 +1,6 @@
+---
+"@comet/brevo-admin": patch
+"@comet/brevo-api": patch
+---
+
+Remove the field `Total contacts blocked` in the Target Groups query, because it is not delivered in the list request in Brevo anymore.

--- a/.changeset/short-feet-sing.md
+++ b/.changeset/short-feet-sing.md
@@ -3,4 +3,4 @@
 "@comet/brevo-api": patch
 ---
 
-Remove the field `Total contacts blocked` in the Target Groups query, because it is not delivered in the list request in Brevo anymore.
+Remove the `totalContactsBlocked` field from the `TargetGroup` type, because it is not delivered in the list request in Brevo anymore.

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -413,7 +413,6 @@ type TargetGroup implements DocumentInterface {
   isMainList: Boolean!
   brevoId: Int!
   totalSubscribers: Int!
-  totalContactsBlocked: Int!
   scope: EmailCampaignContentScope!
   assignedContactsTargetGroupBrevoId: Int
   filters: BrevoContactFilterAttributes

--- a/packages/admin/src/targetGroups/TargetGroupsGrid.tsx
+++ b/packages/admin/src/targetGroups/TargetGroupsGrid.tsx
@@ -48,7 +48,6 @@ const targetGroupsFragment = gql`
         id
         title
         totalSubscribers
-        totalContactsBlocked
         isMainList
     }
 `;
@@ -208,14 +207,6 @@ export function TargetGroupsGrid({
         {
             field: "totalSubscribers",
             headerName: intl.formatMessage({ id: "cometBrevoModule.targetGroup.totalSubscribers", defaultMessage: "Total subscribers" }),
-            type: "number",
-            filterable: false,
-            sortable: false,
-            width: 200,
-        },
-        {
-            field: "totalContactsBlocked",
-            headerName: intl.formatMessage({ id: "cometBrevoModule.targetGroup.totalContactsBlocked", defaultMessage: "Total contacts blocked" }),
             type: "number",
             filterable: false,
             sortable: false,

--- a/packages/api/schema.gql
+++ b/packages/api/schema.gql
@@ -112,7 +112,6 @@ type TargetGroup implements DocumentInterface {
   isMainList: Boolean!
   brevoId: Int!
   totalSubscribers: Int!
-  totalContactsBlocked: Int!
   scope: EmailCampaignContentScope!
   assignedContactsTargetGroupBrevoId: Int
 }

--- a/packages/api/src/target-group/entity/target-group-entity.factory.ts
+++ b/packages/api/src/target-group/entity/target-group-entity.factory.ts
@@ -8,7 +8,7 @@ import { EmailCampaignInterface } from "../../email-campaign/entities/email-camp
 import { BrevoContactFilterAttributesInterface, EmailCampaignScopeInterface } from "../../types";
 
 export interface TargetGroupInterface {
-    [OptionalProps]?: "createdAt" | "updatedAt" | "totalSubscribers" | "totalContactsBlocked";
+    [OptionalProps]?: "createdAt" | "updatedAt" | "totalSubscribers";
     id: string;
     createdAt: Date;
     updatedAt: Date;
@@ -16,7 +16,6 @@ export interface TargetGroupInterface {
     isMainList: boolean;
     brevoId: number;
     totalSubscribers: number;
-    totalContactsBlocked: number;
     scope: EmailCampaignScopeInterface;
     filters?: BrevoContactFilterAttributesInterface;
     assignedContactsTargetGroupBrevoId?: number;
@@ -37,7 +36,7 @@ export class TargetGroupEntityFactory {
             isAbstract: true,
         })
         class TargetGroupBase implements TargetGroupInterface, DocumentInterface {
-            [OptionalProps]?: "createdAt" | "updatedAt" | "totalSubscribers" | "totalContactsBlocked";
+            [OptionalProps]?: "createdAt" | "updatedAt" | "totalSubscribers";
 
             @PrimaryKey({ columnType: "uuid" })
             @Field(() => ID)
@@ -65,9 +64,6 @@ export class TargetGroupEntityFactory {
 
             @Field(() => Int)
             totalSubscribers: number;
-
-            @Field(() => Int)
-            totalContactsBlocked: number;
 
             @Embedded(() => Scope)
             @Field(() => Scope)

--- a/packages/api/src/target-group/target-group.resolver.ts
+++ b/packages/api/src/target-group/target-group.resolver.ts
@@ -75,8 +75,6 @@ export function createTargetGroupsResolver({
 
                 if (brevoContactList) {
                     contactList.totalSubscribers = brevoContactList.uniqueSubscribers;
-                    // TODO: brevo is returning a wrong value for totalBlacklisted
-                    // contactList.totalContactsBlocked = brevoContactList.totalBlacklisted;
                 }
             }
 
@@ -230,15 +228,6 @@ export function createTargetGroupsResolver({
             const { uniqueSubscribers } = await this.brevoApiContactsService.findBrevoContactListById(targetGroup.brevoId, targetGroup.scope);
 
             return uniqueSubscribers;
-        }
-
-        @ResolveField()
-        async totalContactsBlocked(@Parent() targetGroup: TargetGroupInterface): Promise<number> {
-            if (targetGroup.totalContactsBlocked !== undefined) return targetGroup.totalContactsBlocked;
-
-            const { totalBlacklisted } = await this.brevoApiContactsService.findBrevoContactListById(targetGroup.brevoId, targetGroup.scope);
-
-            return totalBlacklisted;
         }
     }
 


### PR DESCRIPTION
## Description

Brevo does not deliver totalBlacklisted anymore in the list query, see: https://developers.brevo.com/reference/getlists-1

<img width="638" alt="Screenshot 2024-11-14 at 07 34 51" src="https://github.com/user-attachments/assets/ee086a27-2d07-4659-8869-ef696a486d62">

Loading the totalBlacklisted count per ResolveField does not work either, because the contacts api is limited:
https://developers.brevo.com/docs/api-limits#general-rate-limiting

We can only make 20 contacts query per second, so when a scope has a lot of target groups, the query just fails.

I removed the blacklisted count for now. Should we decide that we still need it, we will need to sync the data regularly and add it back again.

## Screenshots/screencasts

<img width="1397" alt="Screenshot 2024-11-14 at 07 38 32" src="https://github.com/user-attachments/assets/f686975b-6c82-4ba8-8940-12792dccddee">

## Changeset

[x] I have verified if my change requires a changeset