### PR TITLE
Remove unnecessary axios dependency

### DIFF
--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -86,7 +86,6 @@
         "@mui/material": "^5.8.6",
         "@mui/system": "^5.8.6",
         "@mui/x-data-grid": "^5.17.26",
-        "axios": "^0.21.0",
         "draft-js": "^0.11.0",
         "final-form": "^4.16.1",
         "graphql": "^15.4.0",


### PR DESCRIPTION
## Description

Axios was a peerDependency of comet v.6. In comet v.7 it is no peerDependency anymore, so we can remove it