### PR TITLE
Move scope parts to brevo config

### DIFF
--- a/.changeset/witty-coats-perform.md
+++ b/.changeset/witty-coats-perform.md
@@ -2,15 +2,15 @@
 "@comet/brevo-admin": major
 ---
 
-Define scopeParts in BrevoConfig
+Define `scopeParts` in `BrevoConfig`
 
-Previously the scopeParts had to be defined in the functions:
+Previously the `scopeParts` were passed to the functions:
 
 -   createBrevoContactsPage
 -   createTargetGroupsPage
 -   createEmailCampaignsPage
 
-Now it has to be defined once in the BrevoConfig:
+Now they are defined once in the `BrevoConfig`:
 
 ```tsx
 <BrevoConfigProvider

--- a/.changeset/witty-coats-perform.md
+++ b/.changeset/witty-coats-perform.md
@@ -9,6 +9,7 @@ Previously the `scopeParts` were passed to the functions:
 -   createBrevoContactsPage
 -   createTargetGroupsPage
 -   createEmailCampaignsPage
+-   createBrevoConfigPage
 
 Now they are defined once in the `BrevoConfig`:
 

--- a/.changeset/witty-coats-perform.md
+++ b/.changeset/witty-coats-perform.md
@@ -1,0 +1,24 @@
+---
+"@comet/brevo-admin": major
+---
+
+Define scopeParts in BrevoConfig
+
+Previously the scopeParts had to be defined in the functions:
+
+-   createBrevoContactsPage
+-   createTargetGroupsPage
+-   createEmailCampaignsPage
+
+Now it has to be defined once in the BrevoConfig:
+
+```tsx
+<BrevoConfigProvider
+    value={{
+        scopeParts: ["domain", "language"],
+        ...otherProps,
+    }}
+>
+    {children}
+</BrevoConfigProvider>
+```

--- a/demo/admin/src/App.tsx
+++ b/demo/admin/src/App.tsx
@@ -84,6 +84,7 @@ export function App() {
                                         <SnackbarProvider>
                                             <BrevoConfigProvider
                                                 value={{
+                                                    scopeParts: ["domain", "language"],
                                                     apiUrl: config.apiUrl,
                                                     resolvePreviewUrlForScope: (scope: ContentScope) => {
                                                         return `${config.campaignUrl}/block-preview/${scope.domain}/${scope.language}`;

--- a/demo/admin/src/common/MasterMenu.tsx
+++ b/demo/admin/src/common/MasterMenu.tsx
@@ -1,5 +1,5 @@
 import { Assets, Dashboard, Mail, PageTree, Wrench } from "@comet/admin-icons";
-import { createBrevoConfigPage, createBrevoContactsPage, createEmailCampaignsPage, createTargetGroupsPage } from "@comet/brevo-admin";
+import { BrevoConfigPage, createBrevoContactsPage, createEmailCampaignsPage, createTargetGroupsPage } from "@comet/brevo-admin";
 import {
     AllCategories,
     ContentScopeIndicator,
@@ -55,10 +55,6 @@ const getMasterMenuData = ({ brevoContactConfig }: { brevoContactConfig: BrevoCo
 
     const CampaignsPage = createEmailCampaignsPage({
         EmailCampaignContentBlock,
-    });
-
-    const BrevoConfigPage = createBrevoConfigPage({
-        scopeParts: ["domain", "language"],
     });
 
     return [
@@ -118,7 +114,6 @@ const getMasterMenuData = ({ brevoContactConfig }: { brevoContactConfig: BrevoCo
                         render: () => <TargetGroupsPage />,
                     },
                 },
-<<<<<<< HEAD
                 {
                     type: "route",
                     primary: <FormattedMessage id="menu.newsletter.config" defaultMessage="Config" />,
@@ -127,8 +122,6 @@ const getMasterMenuData = ({ brevoContactConfig }: { brevoContactConfig: BrevoCo
                         render: () => <BrevoConfigPage />,
                     },
                 },
-=======
->>>>>>> a421c92 (add new master menu logic from comet starter to demo)
             ],
             requiredPermission: "brevo-newsletter",
         },

--- a/demo/admin/src/common/MasterMenu.tsx
+++ b/demo/admin/src/common/MasterMenu.tsx
@@ -37,7 +37,6 @@ const RedirectsPage = createRedirectsPage({ scopeParts: ["domain"] });
 
 const getMasterMenuData = ({ brevoContactConfig }: { brevoContactConfig: BrevoContactConfig }): MasterMenuData => {
     const BrevoContactsPage = createBrevoContactsPage({
-        scopeParts: ["domain", "language"],
         additionalAttributesFragment: brevoContactConfig.additionalAttributesFragment,
         additionalGridFields: brevoContactConfig.additionalGridFields,
         additionalFormFields: brevoContactConfig.additionalFormFields,
@@ -45,7 +44,6 @@ const getMasterMenuData = ({ brevoContactConfig }: { brevoContactConfig: BrevoCo
     });
 
     const TargetGroupsPage = createTargetGroupsPage({
-        scopeParts: ["domain", "language"],
         additionalFormFields: additionalFormConfig.additionalFormFields,
         exportTargetGroupOptions: {
             additionalAttributesFragment: brevoContactConfig.additionalAttributesFragment,
@@ -56,7 +54,6 @@ const getMasterMenuData = ({ brevoContactConfig }: { brevoContactConfig: BrevoCo
     });
 
     const CampaignsPage = createEmailCampaignsPage({
-        scopeParts: ["domain", "language"],
         EmailCampaignContentBlock,
     });
 

--- a/demo/admin/src/common/MasterMenu.tsx
+++ b/demo/admin/src/common/MasterMenu.tsx
@@ -121,6 +121,7 @@ const getMasterMenuData = ({ brevoContactConfig }: { brevoContactConfig: BrevoCo
                         render: () => <TargetGroupsPage />,
                     },
                 },
+<<<<<<< HEAD
                 {
                     type: "route",
                     primary: <FormattedMessage id="menu.newsletter.config" defaultMessage="Config" />,
@@ -129,6 +130,8 @@ const getMasterMenuData = ({ brevoContactConfig }: { brevoContactConfig: BrevoCo
                         render: () => <BrevoConfigPage />,
                     },
                 },
+=======
+>>>>>>> a421c92 (add new master menu logic from comet starter to demo)
             ],
             requiredPermission: "brevo-newsletter",
         },

--- a/packages/admin/src/brevoConfiguration/BrevoConfigPage.tsx
+++ b/packages/admin/src/brevoConfiguration/BrevoConfigPage.tsx
@@ -1,22 +1,17 @@
 import { useContentScope } from "@comet/cms-admin";
 import * as React from "react";
 
+import { useBrevoConfig } from "../common/BrevoConfigProvider";
 import { BrevoConfigForm } from "./BrevoConfigForm";
 
-interface CreateBrevoConfigPageOptions {
-    scopeParts: string[];
-}
+export function BrevoConfigPage(): JSX.Element {
+    const { scopeParts } = useBrevoConfig();
+    const { scope: completeScope } = useContentScope();
 
-export function createBrevoConfigPage({ scopeParts }: CreateBrevoConfigPageOptions) {
-    function BrevoConfigPage(): JSX.Element {
-        const { scope: completeScope } = useContentScope();
+    const scope = scopeParts.reduce((acc, scopePart) => {
+        acc[scopePart] = completeScope[scopePart];
+        return acc;
+    }, {} as { [key: string]: unknown });
 
-        const scope = scopeParts.reduce((acc, scopePart) => {
-            acc[scopePart] = completeScope[scopePart];
-            return acc;
-        }, {} as { [key: string]: unknown });
-
-        return <BrevoConfigForm scope={scope} />;
-    }
-    return BrevoConfigPage;
+    return <BrevoConfigForm scope={scope} />;
 }

--- a/packages/admin/src/brevoContacts/BrevoContactsPage.tsx
+++ b/packages/admin/src/brevoContacts/BrevoContactsPage.tsx
@@ -4,11 +4,11 @@ import { DocumentNode } from "graphql";
 import * as React from "react";
 import { useIntl } from "react-intl";
 
+import { useBrevoConfig } from "../common/BrevoConfigProvider";
 import { BrevoContactsGrid } from "./BrevoContactsGrid";
 import { BrevoContactForm, EditBrevoContactFormValues } from "./form/BrevoContactForm";
 
 interface CreateContactsPageOptions {
-    scopeParts: string[];
     additionalAttributesFragment?: { name: string; fragment: DocumentNode };
     additionalGridFields?: GridColDef[];
     additionalFormFields?: React.ReactNode;
@@ -16,7 +16,6 @@ interface CreateContactsPageOptions {
 }
 
 function createBrevoContactsPage({
-    scopeParts,
     additionalAttributesFragment,
     additionalFormFields,
     additionalGridFields,
@@ -24,6 +23,7 @@ function createBrevoContactsPage({
 }: CreateContactsPageOptions) {
     function BrevoContactsPage(): JSX.Element {
         const intl = useIntl();
+        const { scopeParts } = useBrevoConfig();
         const { scope: completeScope } = useContentScope();
 
         const scope = scopeParts.reduce((acc, scopePart) => {

--- a/packages/admin/src/common/BrevoConfigProvider.tsx
+++ b/packages/admin/src/common/BrevoConfigProvider.tsx
@@ -3,6 +3,7 @@ import React from "react";
 
 export interface BrevoConfig {
     apiUrl: string;
+    scopeParts: string[];
     resolvePreviewUrlForScope: (scope: ContentScopeInterface) => string;
 }
 
@@ -19,6 +20,7 @@ export const BrevoConfigProvider = ({ children, value }: React.PropsWithChildren
 interface UseBrevoConfigReturn {
     apiUrl: string;
     previewUrl: string;
+    scopeParts: string[];
 }
 
 export const useBrevoConfig = (): UseBrevoConfigReturn => {

--- a/packages/admin/src/emailCampaigns/EmailCampaignsPage.tsx
+++ b/packages/admin/src/emailCampaigns/EmailCampaignsPage.tsx
@@ -4,18 +4,19 @@ import { ContentScopeIndicator, useContentScope } from "@comet/cms-admin";
 import * as React from "react";
 import { useIntl } from "react-intl";
 
+import { useBrevoConfig } from "../common/BrevoConfigProvider";
 import { EmailCampaignsGrid } from "./EmailCampaignsGrid";
 import { EmailCampaignForm } from "./form/EmailCampaignForm";
 import { EmailCampaignStatistics } from "./statistics/EmailCampaignStatistics";
 import { EmailCampaignView } from "./view/EmailCampaignView";
 
 interface CreateEmailCampaignsPageOptions {
-    scopeParts: string[];
     EmailCampaignContentBlock: BlockInterface;
 }
 
-export function createEmailCampaignsPage({ scopeParts, EmailCampaignContentBlock }: CreateEmailCampaignsPageOptions) {
+export function createEmailCampaignsPage({ EmailCampaignContentBlock }: CreateEmailCampaignsPageOptions) {
     function EmailCampaignsPage(): JSX.Element {
+        const { scopeParts } = useBrevoConfig();
         const { scope: completeScope } = useContentScope();
         const intl = useIntl();
 

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -1,4 +1,4 @@
-export { createBrevoConfigPage } from "./brevoConfiguration/BrevoConfigPage";
+export { BrevoConfigPage } from "./brevoConfiguration/BrevoConfigPage";
 export { createBrevoContactsPage } from "./brevoContacts/BrevoContactsPage";
 export { EditBrevoContactFormValues } from "./brevoContacts/form/BrevoContactForm";
 export { BrevoConfig, BrevoConfigProvider, useBrevoConfig } from "./common/BrevoConfigProvider";

--- a/packages/admin/src/targetGroups/TargetGroupsPage.tsx
+++ b/packages/admin/src/targetGroups/TargetGroupsPage.tsx
@@ -4,11 +4,11 @@ import { DocumentNode } from "graphql";
 import * as React from "react";
 import { useIntl } from "react-intl";
 
+import { useBrevoConfig } from "../common/BrevoConfigProvider";
 import { EditTargetGroupFinalFormValues, TargetGroupForm } from "./TargetGroupForm";
 import { AdditionalContactAttributesType, TargetGroupsGrid } from "./TargetGroupsGrid";
 
 interface CreateContactsPageOptions {
-    scopeParts: string[];
     additionalFormFields?: React.ReactNode;
     exportTargetGroupOptions?: {
         additionalAttributesFragment: { name: string; fragment: DocumentNode };
@@ -19,14 +19,9 @@ interface CreateContactsPageOptions {
     valuesToOutput?: (values: EditTargetGroupFinalFormValues) => EditTargetGroupFinalFormValues;
 }
 
-export function createTargetGroupsPage({
-    scopeParts,
-    additionalFormFields,
-    nodeFragment,
-    input2State,
-    exportTargetGroupOptions,
-}: CreateContactsPageOptions) {
+export function createTargetGroupsPage({ additionalFormFields, nodeFragment, input2State, exportTargetGroupOptions }: CreateContactsPageOptions) {
     function TargetGroupsPage(): JSX.Element {
+        const { scopeParts } = useBrevoConfig();
         const { scope: completeScope } = useContentScope();
         const intl = useIntl();
 

--- a/packages/api/schema.gql
+++ b/packages/api/schema.gql
@@ -1,3 +1,9 @@
+type User {
+  id: String!
+  name: String!
+  email: String!
+}
+
 type CurrentUserPermission {
   permission: String!
   contentScopes: [JSONObject!]!
@@ -35,12 +41,6 @@ enum FocalPoint {
   NORTHEAST
   SOUTHWEST
   SOUTHEAST
-}
-
-type User {
-  id: String!
-  name: String!
-  email: String!
 }
 
 type BrevoApiSender {


### PR DESCRIPTION
depends on [!145](https://github.com/vivid-planet/comet-brevo-module/pull/145)
COM-1053

## Description
I'd like to move the scopeParts to the BrevoConfig, because it only has to be defined once and affects several components.