### PR TITLE
Add folder id to config

### DIFF
--- a/.changeset/new-cobras-thank.md
+++ b/.changeset/new-cobras-thank.md
@@ -1,0 +1,6 @@
+---
+"@comet/brevo-admin": minor
+"@comet/brevo-api": minor
+---
+
+Add `folderId` to `BrevoConfig` to allow overwriting the default folderId `1`

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -460,7 +460,7 @@ type BrevoConfig implements DocumentInterface {
   updatedAt: DateTime!
   senderMail: String!
   senderName: String!
-  folderId: Int
+  folderId: Int!
   createdAt: DateTime!
   scope: EmailCampaignContentScope!
 }

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -460,6 +460,7 @@ type BrevoConfig implements DocumentInterface {
   updatedAt: DateTime!
   senderMail: String!
   senderName: String!
+  folderId: Int
   createdAt: DateTime!
   scope: EmailCampaignContentScope!
 }
@@ -997,9 +998,11 @@ input TargetGroupUpdateInput {
 input BrevoConfigInput {
   senderMail: String!
   senderName: String!
+  folderId: Int!
 }
 
 input BrevoConfigUpdateInput {
   senderMail: String
   senderName: String
+  folderId: Int
 }

--- a/packages/admin/src/brevoConfiguration/BrevoConfigForm.gql.ts
+++ b/packages/admin/src/brevoConfiguration/BrevoConfigForm.gql.ts
@@ -4,6 +4,7 @@ export const brevoConfigFormFragment = gql`
     fragment BrevoConfigForm on BrevoConfig {
         senderMail
         senderName
+        folderId
     }
 `;
 

--- a/packages/admin/src/brevoConfiguration/BrevoConfigForm.tsx
+++ b/packages/admin/src/brevoConfiguration/BrevoConfigForm.tsx
@@ -7,6 +7,7 @@ import {
     FinalFormSubmitEvent,
     Loading,
     MainContent,
+    TextField,
     Toolbar,
     ToolbarActions,
     ToolbarFillSpace,
@@ -76,9 +77,10 @@ export function BrevoConfigForm({ scope }: FormProps): React.ReactElement {
                       value: sender.id,
                       label: `${sender.name} (${sender.email})`,
                   },
+                  folderId: data?.brevoConfig?.folderId,
               }
             : {};
-    }, [data?.brevoConfig?.senderMail, data?.brevoConfig?.senderName, sendersData?.senders]);
+    }, [data?.brevoConfig?.folderId, data?.brevoConfig?.senderMail, data?.brevoConfig?.senderName, sendersData?.senders]);
 
     const saveConflict = useFormSaveConflict({
         checkConflict: async () => {
@@ -117,6 +119,7 @@ export function BrevoConfigForm({ scope }: FormProps): React.ReactElement {
         const output = {
             senderName: sender?.name,
             senderMail: sender?.email,
+            folderId: data?.brevoConfig?.folderId ?? 1,
         };
 
         if (mode === "edit") {
@@ -172,6 +175,11 @@ export function BrevoConfigForm({ scope }: FormProps): React.ReactElement {
                                 options={senderOptions}
                                 name="sender"
                                 label={<FormattedMessage id="cometBrevoModule.brevoConfig.sender" defaultMessage="Sender" />}
+                                fullWidth
+                            />
+                            <TextField
+                                name="folderId"
+                                label={<FormattedMessage id="cometBrevoModule.brevoConfig.folderId" defaultMessage="Folder ID" />}
                                 fullWidth
                             />
                         </MainContent>

--- a/packages/admin/src/brevoConfiguration/BrevoConfigForm.tsx
+++ b/packages/admin/src/brevoConfiguration/BrevoConfigForm.tsx
@@ -155,12 +155,6 @@ export function BrevoConfigForm({ scope }: FormProps): React.ReactElement {
         return <Loading behavior="fillPageHeight" />;
     }
 
-    const validateFolderId = (value: number) => {
-        if (typeof value !== "number") {
-            return <FormattedMessage id="cometBrevoModule.brevoConfig.folderId.validation" defaultMessage="Please enter a number" />;
-        }
-    };
-
     return (
         <FinalForm<FormValues> apiRef={formApiRef} onSubmit={handleSubmit} mode={mode} initialValues={initialValues}>
             {({ values }) => {
@@ -206,7 +200,6 @@ export function BrevoConfigForm({ scope }: FormProps): React.ReactElement {
                                     </>
                                 }
                                 fullWidth
-                                validate={validateFolderId}
                                 required
                             />
                         </MainContent>

--- a/packages/admin/src/brevoConfiguration/BrevoConfigForm.tsx
+++ b/packages/admin/src/brevoConfiguration/BrevoConfigForm.tsx
@@ -7,7 +7,7 @@ import {
     FinalFormSubmitEvent,
     Loading,
     MainContent,
-    TextField,
+    NumberField,
     Toolbar,
     ToolbarActions,
     ToolbarFillSpace,
@@ -38,6 +38,7 @@ interface Option {
 }
 type FormValues = {
     sender: Option;
+    folderId: number;
 };
 
 interface FormProps {
@@ -77,7 +78,7 @@ export function BrevoConfigForm({ scope }: FormProps): React.ReactElement {
                       value: sender.id,
                       label: `${sender.name} (${sender.email})`,
                   },
-                  folderId: data?.brevoConfig?.folderId,
+                  folderId: data?.brevoConfig?.folderId ?? 1,
               }
             : {};
     }, [data?.brevoConfig?.folderId, data?.brevoConfig?.senderMail, data?.brevoConfig?.senderName, sendersData?.senders]);
@@ -119,7 +120,7 @@ export function BrevoConfigForm({ scope }: FormProps): React.ReactElement {
         const output = {
             senderName: sender?.name,
             senderMail: sender?.email,
-            folderId: data?.brevoConfig?.folderId ?? 1,
+            folderId: state.folderId ?? 1,
         };
 
         if (mode === "edit") {
@@ -177,7 +178,7 @@ export function BrevoConfigForm({ scope }: FormProps): React.ReactElement {
                                 label={<FormattedMessage id="cometBrevoModule.brevoConfig.sender" defaultMessage="Sender" />}
                                 fullWidth
                             />
-                            <TextField
+                            <NumberField
                                 name="folderId"
                                 label={<FormattedMessage id="cometBrevoModule.brevoConfig.folderId" defaultMessage="Folder ID" />}
                                 fullWidth

--- a/packages/admin/src/brevoConfiguration/BrevoConfigForm.tsx
+++ b/packages/admin/src/brevoConfiguration/BrevoConfigForm.tsx
@@ -182,6 +182,16 @@ export function BrevoConfigForm({ scope }: FormProps): React.ReactElement {
                                 name="folderId"
                                 label={<FormattedMessage id="cometBrevoModule.brevoConfig.folderId" defaultMessage="Folder ID" />}
                                 fullWidth
+                                validate={(value) => {
+                                    if (typeof value !== "number") {
+                                        return (
+                                            <FormattedMessage
+                                                id="cometBrevoModule.brevoConfig.folderId.validation"
+                                                defaultMessage="Please enter a number"
+                                            />
+                                        );
+                                    }
+                                }}
                             />
                         </MainContent>
                     </>

--- a/packages/admin/src/brevoConfiguration/BrevoConfigForm.tsx
+++ b/packages/admin/src/brevoConfiguration/BrevoConfigForm.tsx
@@ -182,6 +182,7 @@ export function BrevoConfigForm({ scope }: FormProps): React.ReactElement {
                             />
                             <NumberField
                                 name="folderId"
+                                defaultValue={1}
                                 label={
                                     <>
                                         <FormattedMessage id="cometBrevoModule.brevoConfig.folderId" defaultMessage="Folder ID" />

--- a/packages/admin/src/brevoConfiguration/BrevoConfigForm.tsx
+++ b/packages/admin/src/brevoConfiguration/BrevoConfigForm.tsx
@@ -155,6 +155,12 @@ export function BrevoConfigForm({ scope }: FormProps): React.ReactElement {
         return <Loading behavior="fillPageHeight" />;
     }
 
+    const validateFolderId = (value: number) => {
+        if (typeof value !== "number") {
+            return <FormattedMessage id="cometBrevoModule.brevoConfig.folderId.validation" defaultMessage="Please enter a number" />;
+        }
+    };
+
     return (
         <FinalForm<FormValues> apiRef={formApiRef} onSubmit={handleSubmit} mode={mode} initialValues={initialValues}>
             {({ values }) => {
@@ -200,16 +206,7 @@ export function BrevoConfigForm({ scope }: FormProps): React.ReactElement {
                                     </>
                                 }
                                 fullWidth
-                                validate={(value) => {
-                                    if (typeof value !== "number") {
-                                        return (
-                                            <FormattedMessage
-                                                id="cometBrevoModule.brevoConfig.folderId.validation"
-                                                defaultMessage="Please enter a number"
-                                            />
-                                        );
-                                    }
-                                }}
+                                validate={validateFolderId}
                             />
                         </MainContent>
                     </>

--- a/packages/admin/src/brevoConfiguration/BrevoConfigForm.tsx
+++ b/packages/admin/src/brevoConfiguration/BrevoConfigForm.tsx
@@ -207,6 +207,7 @@ export function BrevoConfigForm({ scope }: FormProps): React.ReactElement {
                                 }
                                 fullWidth
                                 validate={validateFolderId}
+                                required
                             />
                         </MainContent>
                     </>

--- a/packages/admin/src/brevoConfiguration/BrevoConfigForm.tsx
+++ b/packages/admin/src/brevoConfiguration/BrevoConfigForm.tsx
@@ -12,9 +12,11 @@ import {
     ToolbarActions,
     ToolbarFillSpace,
     ToolbarTitleItem,
+    Tooltip,
     useFormApiRef,
     useStackSwitchApi,
 } from "@comet/admin";
+import { Info } from "@comet/admin-icons";
 import { ContentScopeIndicator, ContentScopeInterface, resolveHasSaveConflict, useFormSaveConflict } from "@comet/cms-admin";
 import { FormApi } from "final-form";
 import React from "react";
@@ -180,7 +182,22 @@ export function BrevoConfigForm({ scope }: FormProps): React.ReactElement {
                             />
                             <NumberField
                                 name="folderId"
-                                label={<FormattedMessage id="cometBrevoModule.brevoConfig.folderId" defaultMessage="Folder ID" />}
+                                label={
+                                    <>
+                                        <FormattedMessage id="cometBrevoModule.brevoConfig.folderId" defaultMessage="Folder ID" />
+                                        <Tooltip
+                                            title={
+                                                <FormattedMessage
+                                                    id="cometBrevoModule.brevoConfig.folderId.info"
+                                                    defaultMessage="By default, the folder ID should be set to 1 unless you have specifically configured another folder in Brevo."
+                                                />
+                                            }
+                                            sx={{ marginLeft: "5px" }}
+                                        >
+                                            <Info />
+                                        </Tooltip>
+                                    </>
+                                }
                                 fullWidth
                                 validate={(value) => {
                                     if (typeof value !== "number") {

--- a/packages/api/schema.gql
+++ b/packages/api/schema.gql
@@ -185,7 +185,7 @@ type BrevoConfig implements DocumentInterface {
   updatedAt: DateTime!
   senderMail: String!
   senderName: String!
-  folderId: Int
+  folderId: Int!
   createdAt: DateTime!
   scope: EmailCampaignContentScope!
 }

--- a/packages/api/schema.gql
+++ b/packages/api/schema.gql
@@ -1,3 +1,9 @@
+type User {
+  id: String!
+  name: String!
+  email: String!
+}
+
 type CurrentUserPermission {
   permission: String!
   contentScopes: [JSONObject!]!
@@ -35,12 +41,6 @@ enum FocalPoint {
   NORTHEAST
   SOUTHWEST
   SOUTHEAST
-}
-
-type User {
-  id: String!
-  name: String!
-  email: String!
 }
 
 type BrevoApiSender {
@@ -185,6 +185,7 @@ type BrevoConfig implements DocumentInterface {
   updatedAt: DateTime!
   senderMail: String!
   senderName: String!
+  folderId: Int
   createdAt: DateTime!
   scope: EmailCampaignContentScope!
 }
@@ -359,9 +360,11 @@ input SendTestEmailCampaignArgs {
 input BrevoConfigInput {
   senderMail: String!
   senderName: String!
+  folderId: Int!
 }
 
 input BrevoConfigUpdateInput {
   senderMail: String
   senderName: String
+  folderId: Int
 }

--- a/packages/api/src/brevo-api/brevo-api-contact.service.ts
+++ b/packages/api/src/brevo-api/brevo-api-contact.service.ts
@@ -1,5 +1,8 @@
 import * as Brevo from "@getbrevo/brevo";
+import { EntityRepository } from "@mikro-orm/core";
+import { InjectRepository } from "@mikro-orm/nestjs";
 import { Inject, Injectable } from "@nestjs/common";
+import { BrevoConfigInterface } from "src/brevo-config/entities/brevo-config-entity.factory";
 import { BrevoContactAttributesInterface, EmailCampaignScopeInterface } from "src/types";
 
 import { BrevoContactInterface } from "../brevo-contact/dto/brevo-contact.factory";
@@ -18,7 +21,10 @@ export interface CreateDoubleOptInContactData {
 export class BrevoApiContactsService {
     private readonly contactsApis = new Map<string, Brevo.ContactsApi>();
 
-    constructor(@Inject(BREVO_MODULE_CONFIG) private readonly config: BrevoModuleConfig) {}
+    constructor(
+        @Inject(BREVO_MODULE_CONFIG) private readonly config: BrevoModuleConfig,
+        @InjectRepository("BrevoConfig") private readonly brevoConfigRepository: EntityRepository<BrevoConfigInterface>,
+    ) {}
 
     private getContactsApi(scope: EmailCampaignScopeInterface): Brevo.ContactsApi {
         try {
@@ -186,10 +192,12 @@ export class BrevoApiContactsService {
     }
 
     public async createBrevoContactList(title: string, scope: EmailCampaignScopeInterface): Promise<number | undefined> {
+        const brevoConfig = await this.brevoConfigRepository.findOneOrFail({ scope });
+
         try {
             const contactList = {
                 name: title,
-                folderId: 1, // folderId is required, folder #1 is created by default
+                folderId: brevoConfig.folderId ?? 1,
             };
 
             const data = await this.getContactsApi(scope).createList(contactList);

--- a/packages/api/src/brevo-api/brevo-api-contact.service.ts
+++ b/packages/api/src/brevo-api/brevo-api-contact.service.ts
@@ -192,12 +192,12 @@ export class BrevoApiContactsService {
     }
 
     public async createBrevoContactList(title: string, scope: EmailCampaignScopeInterface): Promise<number | undefined> {
-        const brevoConfig = await this.brevoConfigRepository.findOneOrFail({ scope });
+        const brevoConfig = await this.brevoConfigRepository.findOne({ scope });
 
         try {
             const contactList = {
                 name: title,
-                folderId: brevoConfig.folderId ?? 1,
+                folderId: brevoConfig?.folderId ?? 1,
             };
 
             const data = await this.getContactsApi(scope).createList(contactList);

--- a/packages/api/src/brevo-config/dto/brevo-config.input.ts
+++ b/packages/api/src/brevo-config/dto/brevo-config.input.ts
@@ -1,4 +1,4 @@
-import { IsUndefinable, PartialType } from "@comet/cms-api";
+import { PartialType } from "@comet/cms-api";
 import { Field, InputType, Int } from "@nestjs/graphql";
 import { IsEmail, IsInt, IsNotEmpty, IsString } from "class-validator";
 
@@ -15,10 +15,10 @@ export class BrevoConfigInput {
     @Field()
     senderName: string;
 
-    @IsUndefinable()
+    @IsNotEmpty()
     @Field(() => Int)
     @IsInt()
-    folderId?: number;
+    folderId: number;
 }
 
 @InputType()

--- a/packages/api/src/brevo-config/dto/brevo-config.input.ts
+++ b/packages/api/src/brevo-config/dto/brevo-config.input.ts
@@ -15,7 +15,6 @@ export class BrevoConfigInput {
     @Field()
     senderName: string;
 
-    @IsNotEmpty()
     @Field(() => Int)
     @IsInt()
     folderId: number;

--- a/packages/api/src/brevo-config/dto/brevo-config.input.ts
+++ b/packages/api/src/brevo-config/dto/brevo-config.input.ts
@@ -1,6 +1,6 @@
-import { PartialType } from "@comet/cms-api";
-import { Field, InputType } from "@nestjs/graphql";
-import { IsEmail, IsNotEmpty, IsString } from "class-validator";
+import { IsUndefinable, PartialType } from "@comet/cms-api";
+import { Field, InputType, Int } from "@nestjs/graphql";
+import { IsEmail, IsInt, IsNotEmpty, IsString } from "class-validator";
 
 @InputType()
 export class BrevoConfigInput {
@@ -14,6 +14,11 @@ export class BrevoConfigInput {
     @IsString()
     @Field()
     senderName: string;
+
+    @IsUndefinable()
+    @Field(() => Int)
+    @IsInt()
+    folderId?: number;
 }
 
 @InputType()

--- a/packages/api/src/brevo-config/entities/brevo-config-entity.factory.ts
+++ b/packages/api/src/brevo-config/entities/brevo-config-entity.factory.ts
@@ -1,7 +1,7 @@
 import { DocumentInterface } from "@comet/cms-api";
 import { Embedded, Entity, OptionalProps, PrimaryKey, Property } from "@mikro-orm/core";
 import { Type } from "@nestjs/common";
-import { Field, ID, ObjectType } from "@nestjs/graphql";
+import { Field, ID, Int, ObjectType } from "@nestjs/graphql";
 import { v4 } from "uuid";
 
 import { EmailCampaignScopeInterface } from "../../types";
@@ -11,6 +11,7 @@ export interface BrevoConfigInterface {
     id: string;
     senderName: string;
     senderMail: string;
+    folderId?: number;
     createdAt: Date;
     updatedAt: Date;
     scope: EmailCampaignScopeInterface;
@@ -36,6 +37,10 @@ export class BrevoConfigEntityFactory {
             @Property({ columnType: "text" })
             @Field()
             senderName: string;
+
+            @Property({ columnType: "int", nullable: true })
+            @Field(() => Int, { nullable: true })
+            folderId?: number;
 
             @Property({
                 columnType: "timestamp with time zone",

--- a/packages/api/src/brevo-config/entities/brevo-config-entity.factory.ts
+++ b/packages/api/src/brevo-config/entities/brevo-config-entity.factory.ts
@@ -11,7 +11,7 @@ export interface BrevoConfigInterface {
     id: string;
     senderName: string;
     senderMail: string;
-    folderId?: number;
+    folderId: number;
     createdAt: Date;
     updatedAt: Date;
     scope: EmailCampaignScopeInterface;
@@ -38,9 +38,9 @@ export class BrevoConfigEntityFactory {
             @Field()
             senderName: string;
 
-            @Property({ columnType: "int", nullable: true })
-            @Field(() => Int, { nullable: true })
-            folderId?: number;
+            @Property({ columnType: "int" })
+            @Field(() => Int)
+            folderId: number;
 
             @Property({
                 columnType: "timestamp with time zone",

--- a/packages/api/src/mikro-orm/migrations/Migration20241119101706.ts
+++ b/packages/api/src/mikro-orm/migrations/Migration20241119101706.ts
@@ -2,6 +2,6 @@ import { Migration } from "@mikro-orm/migrations";
 
 export class Migration20241119101706 extends Migration {
     async up(): Promise<void> {
-        this.addSql('alter table "BrevoConfig" add column "folderId" int;');
+        this.addSql('alter table "BrevoConfig" add column "folderId" int not null;');
     }
 }

--- a/packages/api/src/mikro-orm/migrations/Migration20241119101706.ts
+++ b/packages/api/src/mikro-orm/migrations/Migration20241119101706.ts
@@ -1,0 +1,7 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20241119101706 extends Migration {
+    async up(): Promise<void> {
+        this.addSql('alter table "BrevoConfig" add column "folderId" int;');
+    }
+}

--- a/packages/api/src/mikro-orm/migrations/Migration20241119101706.ts
+++ b/packages/api/src/mikro-orm/migrations/Migration20241119101706.ts
@@ -2,6 +2,6 @@ import { Migration } from "@mikro-orm/migrations";
 
 export class Migration20241119101706 extends Migration {
     async up(): Promise<void> {
-        this.addSql('alter table "BrevoConfig" add column "folderId" int not null default 1;');
+        this.addSql('alter table "BrevoConfig" add column "folderId" int not null default 1 drop default;');
     }
 }

--- a/packages/api/src/mikro-orm/migrations/Migration20241119101706.ts
+++ b/packages/api/src/mikro-orm/migrations/Migration20241119101706.ts
@@ -2,6 +2,7 @@ import { Migration } from "@mikro-orm/migrations";
 
 export class Migration20241119101706 extends Migration {
     async up(): Promise<void> {
-        this.addSql('alter table "BrevoConfig" add column "folderId" int not null default 1 drop default;');
+        this.addSql('alter table "BrevoConfig" add column "folderId" int not null default 1;');
+        this.addSql('alter table "BrevoConfig" alter column "folderId" drop default;');
     }
 }

--- a/packages/api/src/mikro-orm/migrations/Migration20241119101706.ts
+++ b/packages/api/src/mikro-orm/migrations/Migration20241119101706.ts
@@ -2,6 +2,6 @@ import { Migration } from "@mikro-orm/migrations";
 
 export class Migration20241119101706 extends Migration {
     async up(): Promise<void> {
-        this.addSql('alter table "BrevoConfig" add column "folderId" int not null;');
+        this.addSql('alter table "BrevoConfig" add column "folderId" int not null default 1;');
     }
 }

--- a/packages/api/src/mikro-orm/migrations/migrations.ts
+++ b/packages/api/src/mikro-orm/migrations/migrations.ts
@@ -9,6 +9,7 @@ import { Migration20240619145217 } from "./Migration20240619145217";
 import { Migration20240621102349 } from "./Migration20240621102349";
 import { Migration20240819214939 } from "./Migration20240819214939";
 import { Migration20241016123307 } from "./Migration20241016123307";
+import { Migration20241119101706 } from "./Migration20241119101706";
 
 export const migrationsList: MigrationObject[] = [
     { name: "Migration20240115095733", class: Migration20240115095733 },
@@ -20,4 +21,5 @@ export const migrationsList: MigrationObject[] = [
     { name: "Migration20240621102349", class: Migration20240621102349 },
     { name: "Migration20240819214939", class: Migration20240819214939 },
     { name: "Migration20241016123307", class: Migration20241016123307 },
+    { name: "Migration20241119101706", class: Migration20241119101706 },
 ];


### PR DESCRIPTION
## Description

Add folderId to BrevoConfig to enable overwriting the default folderId (=1) in case the folder was deleted. 


## Screenshots/screencasts

![Screenshot 2024-11-19 at 13 58 30](https://github.com/user-attachments/assets/505277b1-16b3-472a-8e05-8645c62b39d4)
![Screenshot 2024-11-19 at 13 59 12](https://github.com/user-attachments/assets/fd5f78fb-c972-48ba-abd9-d93ed83b38a6)


## Changeset

[x] I have verified if my change requires a changeset

## Related tasks and documents

[COM-1280](https://vivid-planet.atlassian.net/browse/COM-1280)



[COM-1280]: https://vivid-planet.atlassian.net/browse/COM-1280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ