### PR TITLE
Remove type grouping in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,10 +10,6 @@
       "labels": ["comet", "dependencies"]
     },
     {
-      "groupName": "types",
-      "matchPackageNames": ["/@types/*/"]
-    },
-    {
       "groupName": "linters",
       "matchPackageNames": ["/^eslint/", "/^prettier/"]
     },


### PR DESCRIPTION
type groupings can lead to unintended groupings