### PR TITLE
Add `build:packages` alias for `build` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "private": true,
     "scripts": {
         "build": "pnpm recursive run build",
+        "build:packages": "pnpm run build",
         "build:api": "pnpm recursive --filter '@comet/brevo-api' run build",
         "build:admin": "pnpm recursive --filter '@comet/brevo-admin' run build",
         "build:api:skippable": "test -f packages/api/lib/index.d.ts && echo 'Skipping API build' || $npm_execpath build:api",


### PR DESCRIPTION
## Description

It's called `build:packages` in the COMET repo (see https://github.com/vivid-planet/comet/blob/718f0911e1abd2452c0e8241ffffa458af293452/package.json#L12). I have it hardcoded in some helper shell scripts. So I want to add it here too as an alias.