### PR TITLE
Add sendingState filter in EmailCampaignsGrid

### DIFF
--- a/.changeset/green-flies-beam.md
+++ b/.changeset/green-flies-beam.md
@@ -1,0 +1,6 @@
+---
+"@comet/brevo-admin": minor
+"@comet/brevo-api": minor
+---
+
+Add filter for `sendingState` in `EmailCampaignsGrid`

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -666,9 +666,16 @@ input EmailCampaignFilter {
   updatedAt: DateFilter
   title: StringFilter
   subject: StringFilter
+  sendingState: SendingStateEnumFilter
   scheduledAt: DateFilter
   and: [EmailCampaignFilter!]
   or: [EmailCampaignFilter!]
+}
+
+input SendingStateEnumFilter {
+  isAnyOf: [SendingState!]
+  equal: SendingState
+  notEqual: SendingState
 }
 
 input EmailCampaignSort {

--- a/packages/admin/src/emailCampaigns/EmailCampaignsGrid.tsx
+++ b/packages/admin/src/emailCampaigns/EmailCampaignsGrid.tsx
@@ -120,6 +120,15 @@ export function EmailCampaignsGrid({
         ...usePersistentColumnState("EmailCampaignsGrid"),
     };
 
+    const sendingStateOptions: { label: string; value: string }[] = [
+        {
+            value: "SENT",
+            label: intl.formatMessage({ id: "cometBrevoModule.emailCampaign.sent", defaultMessage: "Sent" }),
+        },
+        { value: "DRAFT", label: intl.formatMessage({ id: "cometBrevoModule.emailCampaign.draft", defaultMessage: "Draft" }) },
+        { value: "SCHEDULED", label: intl.formatMessage({ id: "cometBrevoModule.emailCampaign.scheduled", defaultMessage: "Scheduled" }) },
+    ];
+
     const columns: GridColDef<GQLEmailCampaignsListFragment>[] = [
         {
             field: "updatedAt",
@@ -144,8 +153,9 @@ export function EmailCampaignsGrid({
             headerName: intl.formatMessage({ id: "cometBrevoModule.emailCampaign.sendingState", defaultMessage: "Sending State" }),
             renderCell: ({ value }) => <SendingStateColumn sendingState={value} />,
             width: 150,
-            filterable: false,
             sortable: false,
+            type: "singleSelect",
+            valueOptions: sendingStateOptions,
         },
         {
             field: "scheduledAt",

--- a/packages/api/schema.gql
+++ b/packages/api/schema.gql
@@ -227,9 +227,16 @@ input EmailCampaignFilter {
   updatedAt: DateFilter
   title: StringFilter
   subject: StringFilter
+  sendingState: SendingStateEnumFilter
   scheduledAt: DateFilter
   and: [EmailCampaignFilter!]
   or: [EmailCampaignFilter!]
+}
+
+input SendingStateEnumFilter {
+  isAnyOf: [SendingState!]
+  equal: SendingState
+  notEqual: SendingState
 }
 
 input EmailCampaignSort {

--- a/packages/api/src/email-campaign/dto/email-campaign.filter.ts
+++ b/packages/api/src/email-campaign/dto/email-campaign.filter.ts
@@ -1,7 +1,12 @@
-import { DateFilter, StringFilter } from "@comet/cms-api";
+import { createEnumFilter, DateFilter, StringFilter } from "@comet/cms-api";
 import { Field, InputType } from "@nestjs/graphql";
 import { Type } from "class-transformer";
 import { IsOptional, ValidateNested } from "class-validator";
+
+import { SendingState } from "../sending-state.enum";
+
+@InputType()
+class SendingStateEnumFilter extends createEnumFilter(SendingState) {}
 
 @InputType()
 export class EmailCampaignFilter {
@@ -28,6 +33,12 @@ export class EmailCampaignFilter {
     @IsOptional()
     @Type(() => StringFilter)
     subject?: StringFilter;
+
+    @Field(() => SendingStateEnumFilter, { nullable: true })
+    @ValidateNested()
+    @IsOptional()
+    @Type(() => SendingStateEnumFilter)
+    sendingState?: SendingStateEnumFilter;
 
     @Field(() => DateFilter, { nullable: true })
     @ValidateNested()


### PR DESCRIPTION
## Description

The column `sendingState` in the `EmailCampaignsGrid` should be filterable.


## Screenshots/screencasts


https://github.com/user-attachments/assets/683bde4e-48f2-4fe2-ba19-9401e2cc63a1


## Changeset

[x] I have verified if my change requires a changeset

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/COM-1451


## Further information

As you can see in the screencast, the `is not` filter option is not working correctly. This bug will be fixed in Comet.