### PR TITLE
Remove mjml peer dependency from demo campaign

### DIFF
--- a/demo/campaign/package.json
+++ b/demo/campaign/package.json
@@ -72,8 +72,5 @@
         "rimraf": "^3.0.0",
         "tsconfig-paths": "^3.0.0",
         "typescript": "^4.0.0"
-    },
-    "peerDependencies": {
-        "mjml": "^4.7.0"
     }
 }


### PR DESCRIPTION
## Description

Removes mjml as a peer dependency from the demo campaign

It doesn't make sense to have a peer dependency in the demo. I guess this was a copy-paste error. mjml is also installed as a normal dependency.

(I noticed this because of https://github.com/vivid-planet/comet-brevo-module/pull/242/files)