### PR TITLE
Fix generate schema by removing BrevoTestContactUpdateInput

### DIFF
--- a/packages/api/generate-schema.ts
+++ b/packages/api/generate-schema.ts
@@ -62,7 +62,7 @@ async function generateSchema(): Promise<void> {
 
     const BrevoContact = BrevoContactFactory.create({});
     const [BrevoContactInput, BrevoContactUpdateInput] = BrevoContactInputFactory.create({ Scope: EmailCampaignScope });
-    const [BrevoTestContactInput, BrevoTestContactUpdateInput] = BrevoTestContactInputFactory.create({ Scope: EmailCampaignScope });
+    const [BrevoTestContactInput] = BrevoTestContactInputFactory.create({ Scope: EmailCampaignScope });
 
     const BrevoContactSubscribeInput = SubscribeInputFactory.create({ Scope: EmailCampaignScope });
     const BrevoContactResolver = createBrevoContactResolver({
@@ -72,7 +72,6 @@ async function generateSchema(): Promise<void> {
         BrevoContactInput,
         BrevoContactUpdateInput,
         BrevoTestContactInput,
-        BrevoTestContactUpdateInput,
     });
 
     const TargetGroup = TargetGroupEntityFactory.create({ Scope: EmailCampaignScope });

--- a/packages/api/schema.gql
+++ b/packages/api/schema.gql
@@ -110,7 +110,7 @@ type TargetGroup implements DocumentInterface {
   createdAt: DateTime!
   title: String!
   isMainList: Boolean!
-  isTestList: Boolean
+  isTestList: Boolean!
   brevoId: Int!
   totalSubscribers: Int!
   scope: EmailCampaignContentScope!

--- a/packages/api/src/brevo-contact/dto/brevo-test-contact-input.factory.ts
+++ b/packages/api/src/brevo-contact/dto/brevo-test-contact-input.factory.ts
@@ -12,11 +12,6 @@ export interface BrevoTestContactInputInterface {
     attributes?: BrevoContactAttributesInterface;
 }
 
-export interface BrevoTestContactUpdateInputInterface {
-    blocked?: boolean;
-    attributes?: BrevoContactAttributesInterface;
-}
-
 export class BrevoTestContactInputFactory {
     static create({
         BrevoContactAttributes,


### PR DESCRIPTION
## Description
Fix: Generating a schema is not possible, as BrevoTestContactUpdateInput is not used in createBrevoContactResolver. Remove BrevoTestContactUpdateInput and also its type.
