### PR TITLE
Skip canary release on stable releases

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -34,7 +34,7 @@ jobs:
         run: pnpm run copy-schema-files
 
       - name: Publish Canary release
-        if: ${{ github.ref_name == 'main' }}
+        if: ${{ github.ref_name == 'main' && !contains(github.event.head_commit.message, 'Version Packages') }}
         run: |
           echo --- > .changeset/canary.md
           echo '"@comet/brevo-admin": patch' >> .changeset/canary.md
@@ -47,7 +47,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish Canary release
-        if: ${{ github.ref_name == 'next' }}
+        if: ${{ github.ref_name == 'next' && !contains(github.event.head_commit.message, 'Version Packages') }}
         run: |
           echo --- > .changeset/canary.md
           echo '"@comet/brevo-admin": major' >> .changeset/canary.md


### PR DESCRIPTION
## Description

This prevents that the release fails because two versions are published at the same time (like https://github.com/vivid-planet/comet-brevo-module/actions/runs/12884734218/job/35921685341)

see https://github.com/vivid-planet/comet/pull/2194