### PR TITLE
Add check for valid folderId

### DIFF
--- a/packages/api/src/brevo-api/brevo-api-folders.service.ts
+++ b/packages/api/src/brevo-api/brevo-api-folders.service.ts
@@ -1,0 +1,34 @@
+import * as Brevo from "@getbrevo/brevo";
+import { Inject, Injectable } from "@nestjs/common";
+import { EmailCampaignScopeInterface } from "src/types";
+
+import { BrevoModuleConfig } from "../config/brevo-module.config";
+import { BREVO_MODULE_CONFIG } from "../config/brevo-module.constants";
+import { BrevoApiFolder } from "./dto/brevo-api-folder";
+
+@Injectable()
+export class BrevoApiFoldersService {
+    private readonly contactsApi: Brevo.ContactsApi;
+
+    constructor(@Inject(BREVO_MODULE_CONFIG) private readonly config: BrevoModuleConfig) {
+        this.contactsApi = new Brevo.ContactsApi();
+    }
+
+    public async getFolders(scope: EmailCampaignScopeInterface): Promise<Array<BrevoApiFolder> | undefined> {
+        const apiKey = this.config.brevo.resolveConfig(scope).apiKey;
+        this.contactsApi.setApiKey(Brevo.ContactsApiApiKeys.apiKey, apiKey);
+
+        // Limit set by Brevo
+        const limit = 50;
+
+        const offset = 0;
+
+        const { response, body } = await this.contactsApi.getFolders(limit, offset);
+
+        if (response.statusCode !== 200) {
+            throw new Error("Failed to get folders");
+        }
+
+        return body.folders as BrevoApiFolder[];
+    }
+}

--- a/packages/api/src/brevo-api/brevo-api-folders.service.ts
+++ b/packages/api/src/brevo-api/brevo-api-folders.service.ts
@@ -4,6 +4,7 @@ import { EmailCampaignScopeInterface } from "src/types";
 
 import { BrevoModuleConfig } from "../config/brevo-module.config";
 import { BREVO_MODULE_CONFIG } from "../config/brevo-module.constants";
+import { handleBrevoError } from "./brevo-api.utils";
 import { BrevoApiFolder } from "./dto/brevo-api-folder";
 
 @Injectable()
@@ -14,21 +15,33 @@ export class BrevoApiFoldersService {
         this.contactsApi = new Brevo.ContactsApi();
     }
 
-    public async getFolders(scope: EmailCampaignScopeInterface): Promise<Array<BrevoApiFolder> | undefined> {
+    async *getAllBrevoFolders(scope: EmailCampaignScopeInterface): AsyncGenerator<BrevoApiFolder, void, undefined> {
         const apiKey = this.config.brevo.resolveConfig(scope).apiKey;
         this.contactsApi.setApiKey(Brevo.ContactsApiApiKeys.apiKey, apiKey);
 
         // Limit set by Brevo
         const limit = 50;
+        let offset = 0;
 
-        const offset = 0;
+        while (true) {
+            try {
+                const { response, body } = await this.contactsApi.getFolders(limit, offset);
 
-        const { response, body } = await this.contactsApi.getFolders(limit, offset);
+                if (response.statusCode !== 200) {
+                    throw new Error("Failed to get folders");
+                }
 
-        if (response.statusCode !== 200) {
-            throw new Error("Failed to get folders");
+                const folders = body.folders ?? [];
+                if (folders.length === 0) {
+                    break;
+                }
+
+                yield* folders;
+
+                offset += limit;
+            } catch (error) {
+                handleBrevoError(error);
+            }
         }
-
-        return body.folders as BrevoApiFolder[];
     }
 }

--- a/packages/api/src/brevo-api/brevo-api.module.ts
+++ b/packages/api/src/brevo-api/brevo-api.module.ts
@@ -5,12 +5,13 @@ import { Module } from "@nestjs/common";
 import { ConfigModule } from "../config/config.module";
 import { BrevoApiCampaignsService } from "./brevo-api-campaigns.service";
 import { BrevoApiContactsService } from "./brevo-api-contact.service";
+import { BrevoApiFoldersService } from "./brevo-api-folders.service";
 import { BrevoApiSenderService } from "./brevo-api-sender.service";
 import { BrevoTransactionalMailsService } from "./brevo-api-transactional-mails.service";
 
 @Module({
     imports: [ConfigModule, CacheModule.register({ ttl: 1000 * 60 }), MikroOrmModule.forFeature(["BrevoConfig"])],
-    providers: [BrevoApiContactsService, BrevoApiCampaignsService, BrevoTransactionalMailsService, BrevoApiSenderService],
-    exports: [BrevoApiContactsService, BrevoApiCampaignsService, BrevoTransactionalMailsService, BrevoApiSenderService],
+    providers: [BrevoApiContactsService, BrevoApiCampaignsService, BrevoTransactionalMailsService, BrevoApiSenderService, BrevoApiFoldersService],
+    exports: [BrevoApiContactsService, BrevoApiCampaignsService, BrevoTransactionalMailsService, BrevoApiSenderService, BrevoApiFoldersService],
 })
 export class BrevoApiModule {}

--- a/packages/api/src/brevo-api/dto/brevo-api-folder.ts
+++ b/packages/api/src/brevo-api/dto/brevo-api-folder.ts
@@ -1,0 +1,10 @@
+import { Field, ID, ObjectType } from "@nestjs/graphql";
+
+@ObjectType()
+export class BrevoApiFolder {
+    @Field(() => ID)
+    id: number;
+
+    @Field(() => String)
+    name: string;
+}

--- a/packages/api/src/brevo-config/brevo-config.resolver.ts
+++ b/packages/api/src/brevo-config/brevo-config.resolver.ts
@@ -56,8 +56,6 @@ export function createBrevoConfigResolver({
             for await (const folder of this.brevoFolderIdService.getAllBrevoFolders(Scope)) {
                 if (folder.id === folderId) {
                     return true;
-                } else {
-                    throw new Error("Folder id is not valid. ");
                 }
             }
             return false;

--- a/packages/api/src/brevo-config/brevo-config.resolver.ts
+++ b/packages/api/src/brevo-config/brevo-config.resolver.ts
@@ -53,12 +53,13 @@ export function createBrevoConfigResolver({
         }
 
         private async isValidFolderId({ folderId }: { folderId: number }): Promise<boolean> {
-            const folders = await this.brevoFolderIdService.getFolders(Scope);
-
-            if (folders && folders.some((folder) => folder.id === folderId)) {
-                return true;
+            for await (const folder of this.brevoFolderIdService.getAllBrevoFolders(Scope)) {
+                if (folder.id === folderId) {
+                    return true;
+                } else {
+                    throw new Error("Folder id is not valid. ");
+                }
             }
-
             return false;
         }
 


### PR DESCRIPTION
Add validation for folderId in the BrevoConfig to only allow entering ids, that actually exist.

Task: [COM-1577](https://vivid-planet.atlassian.net/browse/COM-1577)


[COM-1577]: https://vivid-planet.atlassian.net/browse/COM-1577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ