### PR TITLE
Add migration to set config folderId value in demo

### DIFF
--- a/demo/api/src/db/migrations/Migration20250123082436.ts
+++ b/demo/api/src/db/migrations/Migration20250123082436.ts
@@ -1,0 +1,16 @@
+import { Migration } from "@mikro-orm/migrations";
+import { v4 } from "uuid";
+
+export class Migration20250123082436 extends Migration {
+    async up(): Promise<void> {
+        const id = v4();
+
+        this.addSql(`
+        insert into "BrevoConfig" (
+            "id", "createdAt", "updatedAt", "scope_domain", "scope_language", "senderMail", "senderName", "doubleOptInTemplateId", "allowedRedirectionUrl", "unsubscriptionPageId", "folderId"
+        ) values (
+          '${id}', now(), now(), 'main', 'en', '', '', 1, '', '', 457 
+        );
+    `);
+    }
+}


### PR DESCRIPTION
## Description

Problem: the default folderId is 1. This folder was deleted in the demo project, what causes unclear error messages.

To make it easier for devs checking out the demo project, the folderId is set to the active folderId.


Task: [COM-1577](https://vivid-planet.atlassian.net/browse/COM-1577)


[COM-1577]: https://vivid-planet.atlassian.net/browse/COM-1577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ