### PR TITLE
Add ConfigVerification to all Brevo Pages

### DIFF
--- a/.changeset/five-ways-sort.md
+++ b/.changeset/five-ways-sort.md
@@ -1,0 +1,5 @@
+---
+"@comet/brevo-admin": minor
+---
+
+Add `ConfigVerification` to all pages to guarantee that the config is set

--- a/packages/admin/src/brevoContacts/BrevoContactsPage.tsx
+++ b/packages/admin/src/brevoContacts/BrevoContactsPage.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 import { useIntl } from "react-intl";
 
 import { useBrevoConfig } from "../common/BrevoConfigProvider";
+import { ConfigVerification } from "../configVerification/ConfigVerification";
 import { BrevoContactsGrid } from "./BrevoContactsGrid";
 import { BrevoContactForm, EditBrevoContactFormValues } from "./form/BrevoContactForm";
 
@@ -32,43 +33,45 @@ function createBrevoContactsPage({
         }, {} as { [key: string]: unknown });
 
         return (
-            <Stack topLevelTitle={intl.formatMessage({ id: "cometBrevoModule.brevoContacts.brevoContacts", defaultMessage: "Contacts" })}>
-                <StackSwitch>
-                    <StackPage name="grid">
-                        <StackToolbar scopeIndicator={<ContentScopeIndicator scope={scope} />} />
-                        <BrevoContactsGrid
-                            scope={scope}
-                            additionalAttributesFragment={additionalAttributesFragment}
-                            additionalGridFields={additionalGridFields}
-                        />
-                    </StackPage>
-                    <StackPage
-                        name="edit"
-                        title={intl.formatMessage({ id: "cometBrevoModule.brevoContacts.editBrevoContact", defaultMessage: "Edit contact" })}
-                    >
-                        {(selectedId) => (
+            <ConfigVerification scope={scope}>
+                <Stack topLevelTitle={intl.formatMessage({ id: "cometBrevoModule.brevoContacts.brevoContacts", defaultMessage: "Contacts" })}>
+                    <StackSwitch>
+                        <StackPage name="grid">
+                            <StackToolbar scopeIndicator={<ContentScopeIndicator scope={scope} />} />
+                            <BrevoContactsGrid
+                                scope={scope}
+                                additionalAttributesFragment={additionalAttributesFragment}
+                                additionalGridFields={additionalGridFields}
+                            />
+                        </StackPage>
+                        <StackPage
+                            name="edit"
+                            title={intl.formatMessage({ id: "cometBrevoModule.brevoContacts.editBrevoContact", defaultMessage: "Edit contact" })}
+                        >
+                            {(selectedId) => (
+                                <BrevoContactForm
+                                    additionalFormFields={additionalFormFields}
+                                    additionalAttributesFragment={additionalAttributesFragment}
+                                    input2State={input2State}
+                                    id={Number(selectedId)}
+                                    scope={scope}
+                                />
+                            )}
+                        </StackPage>
+                        <StackPage
+                            name="add"
+                            title={intl.formatMessage({ id: "cometBrevoModule.brevoContacts.addBrevoContact", defaultMessage: "Add contact" })}
+                        >
                             <BrevoContactForm
                                 additionalFormFields={additionalFormFields}
                                 additionalAttributesFragment={additionalAttributesFragment}
                                 input2State={input2State}
-                                id={Number(selectedId)}
                                 scope={scope}
                             />
-                        )}
-                    </StackPage>
-                    <StackPage
-                        name="add"
-                        title={intl.formatMessage({ id: "cometBrevoModule.brevoContacts.addBrevoContact", defaultMessage: "Add contact" })}
-                    >
-                        <BrevoContactForm
-                            additionalFormFields={additionalFormFields}
-                            additionalAttributesFragment={additionalAttributesFragment}
-                            input2State={input2State}
-                            scope={scope}
-                        />
-                    </StackPage>
-                </StackSwitch>
-            </Stack>
+                        </StackPage>
+                    </StackSwitch>
+                </Stack>
+            </ConfigVerification>
         );
     }
 

--- a/packages/admin/src/brevoTestContacts/BrevoTestContactsPage.tsx
+++ b/packages/admin/src/brevoTestContacts/BrevoTestContactsPage.tsx
@@ -4,6 +4,7 @@ import { DocumentNode } from "graphql";
 import * as React from "react";
 import { useIntl } from "react-intl";
 
+import { ConfigVerification } from "../configVerification/ConfigVerification";
 import { BrevoTestContactsGrid } from "./BrevoTestContactsGrid";
 import { BrevoTestContactForm, EditBrevoContactFormValues } from "./form/BrevoTestContactForm";
 
@@ -32,43 +33,47 @@ function createBrevoTestContactsPage({
         }, {} as { [key: string]: unknown });
 
         return (
-            <Stack topLevelTitle={intl.formatMessage({ id: "cometBrevoModule.brevoContacts.brevoTestContacts", defaultMessage: "Test Contacts" })}>
-                <StackSwitch>
-                    <StackPage name="grid">
-                        <StackToolbar scopeIndicator={<ContentScopeIndicator scope={scope} />} />
-                        <BrevoTestContactsGrid
-                            scope={scope}
-                            additionalAttributesFragment={additionalAttributesFragment}
-                            additionalGridFields={additionalGridFields}
-                        />
-                    </StackPage>
-                    <StackPage
-                        name="edit"
-                        title={intl.formatMessage({ id: "cometBrevoModule.brevoContacts.editBrevoContact", defaultMessage: "Edit contact" })}
-                    >
-                        {(selectedId) => (
+            <ConfigVerification scope={scope}>
+                <Stack
+                    topLevelTitle={intl.formatMessage({ id: "cometBrevoModule.brevoContacts.brevoTestContacts", defaultMessage: "Test Contacts" })}
+                >
+                    <StackSwitch>
+                        <StackPage name="grid">
+                            <StackToolbar scopeIndicator={<ContentScopeIndicator scope={scope} />} />
+                            <BrevoTestContactsGrid
+                                scope={scope}
+                                additionalAttributesFragment={additionalAttributesFragment}
+                                additionalGridFields={additionalGridFields}
+                            />
+                        </StackPage>
+                        <StackPage
+                            name="edit"
+                            title={intl.formatMessage({ id: "cometBrevoModule.brevoContacts.editBrevoContact", defaultMessage: "Edit contact" })}
+                        >
+                            {(selectedId) => (
+                                <BrevoTestContactForm
+                                    additionalFormFields={additionalFormFields}
+                                    additionalAttributesFragment={additionalAttributesFragment}
+                                    input2State={input2State}
+                                    id={Number(selectedId)}
+                                    scope={scope}
+                                />
+                            )}
+                        </StackPage>
+                        <StackPage
+                            name="add"
+                            title={intl.formatMessage({ id: "cometBrevoModule.brevoContacts.addBrevoContact", defaultMessage: "Add contact" })}
+                        >
                             <BrevoTestContactForm
                                 additionalFormFields={additionalFormFields}
                                 additionalAttributesFragment={additionalAttributesFragment}
                                 input2State={input2State}
-                                id={Number(selectedId)}
                                 scope={scope}
                             />
-                        )}
-                    </StackPage>
-                    <StackPage
-                        name="add"
-                        title={intl.formatMessage({ id: "cometBrevoModule.brevoContacts.addBrevoContact", defaultMessage: "Add contact" })}
-                    >
-                        <BrevoTestContactForm
-                            additionalFormFields={additionalFormFields}
-                            additionalAttributesFragment={additionalAttributesFragment}
-                            input2State={input2State}
-                            scope={scope}
-                        />
-                    </StackPage>
-                </StackSwitch>
-            </Stack>
+                        </StackPage>
+                    </StackSwitch>
+                </Stack>
+            </ConfigVerification>
         );
     }
 

--- a/packages/admin/src/configVerification/ConfigVerification.gql.ts
+++ b/packages/admin/src/configVerification/ConfigVerification.gql.ts
@@ -1,0 +1,9 @@
+import { gql } from "@apollo/client";
+
+export const brevoConfigCheckQuery = gql`
+    query BrevoConfigCheck($scope: EmailCampaignContentScopeInput!) {
+        brevoConfig(scope: $scope) {
+            id
+        }
+    }
+`;

--- a/packages/admin/src/configVerification/ConfigVerification.tsx
+++ b/packages/admin/src/configVerification/ConfigVerification.tsx
@@ -1,0 +1,40 @@
+import { useQuery } from "@apollo/client";
+import { Alert, Loading, MainContent } from "@comet/admin";
+import { ContentScopeInterface } from "@comet/cms-admin";
+import * as React from "react";
+import { FormattedMessage } from "react-intl";
+
+import { brevoConfigCheckQuery } from "./ConfigVerification.gql";
+import { GQLBrevoConfigCheckQuery, GQLBrevoConfigCheckQueryVariables } from "./ConfigVerification.gql.generated";
+
+interface ConfigCheckProps {
+    scope: ContentScopeInterface;
+}
+
+export function ConfigVerification({ scope, children }: React.PropsWithChildren<ConfigCheckProps>): JSX.Element {
+    const { data, error, loading } = useQuery<GQLBrevoConfigCheckQuery, GQLBrevoConfigCheckQueryVariables>(brevoConfigCheckQuery, {
+        variables: { scope },
+        fetchPolicy: "cache-and-network",
+    });
+
+    if (error) throw error;
+
+    if (loading) {
+        return <Loading behavior="fillPageHeight" />;
+    }
+
+    if (!data?.brevoConfig?.id) {
+        return (
+            <MainContent>
+                <Alert severity="error">
+                    <FormattedMessage
+                        id="cometBrevoModule.missingConfig"
+                        defaultMessage="Missing brevo config! Configure brevo via the config page."
+                    />
+                </Alert>
+            </MainContent>
+        );
+    }
+
+    return <>{children}</>;
+}

--- a/packages/admin/src/emailCampaigns/EmailCampaignsPage.tsx
+++ b/packages/admin/src/emailCampaigns/EmailCampaignsPage.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 import { useIntl } from "react-intl";
 
 import { useBrevoConfig } from "../common/BrevoConfigProvider";
+import { ConfigVerification } from "../configVerification/ConfigVerification";
 import { EmailCampaignsGrid } from "./EmailCampaignsGrid";
 import { EmailCampaignForm } from "./form/EmailCampaignForm";
 import { EmailCampaignStatistics } from "./statistics/EmailCampaignStatistics";
@@ -26,31 +27,43 @@ export function createEmailCampaignsPage({ EmailCampaignContentBlock }: CreateEm
         }, {} as { [key: string]: unknown });
 
         return (
-            <Stack topLevelTitle={intl.formatMessage({ id: "cometBrevoModule.emailCampaigns.emailCampaigns", defaultMessage: "Email campaigns" })}>
-                <StackSwitch>
-                    <StackPage name="grid">
-                        <StackToolbar scopeIndicator={<ContentScopeIndicator scope={scope} />} />
-                        <EmailCampaignsGrid scope={scope} EmailCampaignContentBlock={EmailCampaignContentBlock} />
-                    </StackPage>
-                    <StackPage name="statistics">{(selectedId) => <EmailCampaignStatistics id={selectedId} />}</StackPage>
-                    <StackPage name="view">
-                        {(selectedId) => <EmailCampaignView id={selectedId} EmailCampaignContentBlock={EmailCampaignContentBlock} />}
-                    </StackPage>
+            <ConfigVerification scope={scope}>
+                <Stack
+                    topLevelTitle={intl.formatMessage({ id: "cometBrevoModule.emailCampaigns.emailCampaigns", defaultMessage: "Email campaigns" })}
+                >
+                    <StackSwitch>
+                        <StackPage name="grid">
+                            <StackToolbar scopeIndicator={<ContentScopeIndicator scope={scope} />} />
+                            <EmailCampaignsGrid scope={scope} EmailCampaignContentBlock={EmailCampaignContentBlock} />
+                        </StackPage>
+                        <StackPage name="statistics">{(selectedId) => <EmailCampaignStatistics id={selectedId} />}</StackPage>
+                        <StackPage name="view">
+                            {(selectedId) => <EmailCampaignView id={selectedId} EmailCampaignContentBlock={EmailCampaignContentBlock} />}
+                        </StackPage>
 
-                    <StackPage
-                        name="edit"
-                        title={intl.formatMessage({ id: "cometBrevoModule.emailCampaigns.editEmailCampaign", defaultMessage: "Edit email campaign" })}
-                    >
-                        {(selectedId) => <EmailCampaignForm id={selectedId} EmailCampaignContentBlock={EmailCampaignContentBlock} scope={scope} />}
-                    </StackPage>
-                    <StackPage
-                        name="add"
-                        title={intl.formatMessage({ id: "cometBrevoModule.emailCampaigns.addEmailCampaign", defaultMessage: "Add email campaign" })}
-                    >
-                        <EmailCampaignForm EmailCampaignContentBlock={EmailCampaignContentBlock} scope={scope} />
-                    </StackPage>
-                </StackSwitch>
-            </Stack>
+                        <StackPage
+                            name="edit"
+                            title={intl.formatMessage({
+                                id: "cometBrevoModule.emailCampaigns.editEmailCampaign",
+                                defaultMessage: "Edit email campaign",
+                            })}
+                        >
+                            {(selectedId) => (
+                                <EmailCampaignForm id={selectedId} EmailCampaignContentBlock={EmailCampaignContentBlock} scope={scope} />
+                            )}
+                        </StackPage>
+                        <StackPage
+                            name="add"
+                            title={intl.formatMessage({
+                                id: "cometBrevoModule.emailCampaigns.addEmailCampaign",
+                                defaultMessage: "Add email campaign",
+                            })}
+                        >
+                            <EmailCampaignForm EmailCampaignContentBlock={EmailCampaignContentBlock} scope={scope} />
+                        </StackPage>
+                    </StackSwitch>
+                </Stack>
+            </ConfigVerification>
         );
     }
     return EmailCampaignsPage;

--- a/packages/admin/src/targetGroups/TargetGroupsPage.tsx
+++ b/packages/admin/src/targetGroups/TargetGroupsPage.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 import { useIntl } from "react-intl";
 
 import { useBrevoConfig } from "../common/BrevoConfigProvider";
+import { ConfigVerification } from "../configVerification/ConfigVerification";
 import { EditTargetGroupFinalFormValues, TargetGroupForm } from "./TargetGroupForm";
 import { AdditionalContactAttributesType, TargetGroupsGrid } from "./TargetGroupsGrid";
 
@@ -31,28 +32,30 @@ export function createTargetGroupsPage({ additionalFormFields, nodeFragment, inp
         }, {} as { [key: string]: unknown });
 
         return (
-            <Stack topLevelTitle={intl.formatMessage({ id: "cometBrevoModule.targetGroups.targetGroups", defaultMessage: "Target groups" })}>
-                <StackSwitch>
-                    <StackPage name="grid">
-                        <Toolbar scopeIndicator={<ContentScopeIndicator scope={scope} />} />
-                        <TargetGroupsGrid scope={scope} exportTargetGroupOptions={exportTargetGroupOptions} />
-                    </StackPage>
-                    <StackPage
-                        name="edit"
-                        title={intl.formatMessage({ id: "cometBrevoModule.targetGroups.editTargetGroup", defaultMessage: "Edit target group" })}
-                    >
-                        {(selectedId) => (
-                            <TargetGroupForm
-                                id={selectedId}
-                                scope={scope}
-                                additionalFormFields={additionalFormFields}
-                                nodeFragment={nodeFragment}
-                                input2State={input2State}
-                            />
-                        )}
-                    </StackPage>
-                </StackSwitch>
-            </Stack>
+            <ConfigVerification scope={scope}>
+                <Stack topLevelTitle={intl.formatMessage({ id: "cometBrevoModule.targetGroups.targetGroups", defaultMessage: "Target groups" })}>
+                    <StackSwitch>
+                        <StackPage name="grid">
+                            <Toolbar scopeIndicator={<ContentScopeIndicator scope={scope} />} />
+                            <TargetGroupsGrid scope={scope} exportTargetGroupOptions={exportTargetGroupOptions} />
+                        </StackPage>
+                        <StackPage
+                            name="edit"
+                            title={intl.formatMessage({ id: "cometBrevoModule.targetGroups.editTargetGroup", defaultMessage: "Edit target group" })}
+                        >
+                            {(selectedId) => (
+                                <TargetGroupForm
+                                    id={selectedId}
+                                    scope={scope}
+                                    additionalFormFields={additionalFormFields}
+                                    nodeFragment={nodeFragment}
+                                    input2State={input2State}
+                                />
+                            )}
+                        </StackPage>
+                    </StackSwitch>
+                </Stack>
+            </ConfigVerification>
         );
     }
 


### PR DESCRIPTION
## Description

Add `ConfigVerification` to all Brevo pages to display an error, if the config is not set. 


## Screenshots/screencasts

![Screenshot 2025-01-24 at 11 07 30](https://github.com/user-attachments/assets/4b1c6b7a-6a2f-4a83-9b36-1b8764babc0e)

## Changeset

[x] I have verified if my change requires a changeset

## Related tasks and documents

[COM-1577](https://vivid-planet.atlassian.net/browse/COM-1577)



[COM-1577]: https://vivid-planet.atlassian.net/browse/COM-1577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ