### PR TITLE
Fix scope passed to brevoTestContactsSelectQuery

### DIFF
--- a/.changeset/wet-news-sit.md
+++ b/.changeset/wet-news-sit.md
@@ -1,0 +1,5 @@
+---
+"@comet/brevo-admin": minor
+---
+
+Fix scope in brevoTestContactsSelectQuery

--- a/.changeset/wet-news-sit.md
+++ b/.changeset/wet-news-sit.md
@@ -1,5 +1,5 @@
 ---
-"@comet/brevo-admin": minor
+"@comet/brevo-admin": patch
 ---
 
 Fix scope in brevoTestContactsSelectQuery

--- a/packages/admin/src/emailCampaigns/form/TestEmailCampaignForm.tsx
+++ b/packages/admin/src/emailCampaigns/form/TestEmailCampaignForm.tsx
@@ -7,6 +7,7 @@ import { Card } from "@mui/material";
 import React from "react";
 import { FormattedMessage } from "react-intl";
 
+import { useBrevoConfig } from "../../common/BrevoConfigProvider";
 import { GQLBrevoTestContactsSelectListFragment } from "./TestEmailCampaignForm.generated";
 import { SendEmailCampaignToTestEmailsMutation } from "./TestEmailCampaignForm.gql";
 import { GQLSendEmailCampaignToTestEmailsMutation, GQLSendEmailCampaignToTestEmailsMutationVariables } from "./TestEmailCampaignForm.gql.generated";
@@ -41,7 +42,14 @@ const brevoTestContactsSelectQuery = gql`
 
 export const TestEmailCampaignForm = ({ id, isSendable = false }: TestEmailCampaignFormProps) => {
     const client = useApolloClient();
-    const scope = useContentScope();
+
+    const { scopeParts } = useBrevoConfig();
+    const { scope: completeScope } = useContentScope();
+
+    const scope = scopeParts.reduce((acc, scopePart) => {
+        acc[scopePart] = completeScope[scopePart];
+        return acc;
+    }, {} as { [key: string]: unknown });
 
     // Contact creation is limited to 100 at a time. Therefore, 100 contacts are queried without using pagination.
     const { data, loading, error } = useQuery(brevoTestContactsSelectQuery, {


### PR DESCRIPTION
## Description

Pass scope correctly to `brevoTestContactsSelectQuery`

<!--

Everything below this is intended to help ease reviewing this PR.
Remove all unrelated sections.

-->

## Example

<!--

Make sure to provide an example of your change if your change includes a new API.

This can be either:
-   The implementation in Demo
-   A unit test

--->

[x] I have verified if my change requires an example

## Screenshots/screencasts

<!--

When making a visual change, please provide either screenshots or screencasts.

Hint: For before/after views, you can use a table:

| Before   | After   |
| -------- | ------- |
| Link     | Link    |

-->

## Changeset

<!--

When making a notable change, make sure to add a changeset.
See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md) for more information.

TL;DR

Add a changeset when:
-   changing the package's public API (`src/index.ts`)
-   fixing a bug
-   making a visual change

Changeset writing guidelines:
-   Use active voice: "Add new thing" vs. "A new thing is added"
-   First line should be the title: "Add new alert component"
-   Provide additional information in the description
-   Use backticks to highlight code: Add new `Alert` component
-   Use bold formatting for "headlines" in the description: **Example**

--->

[x] I have verified if my change requires a changeset

## Related tasks and documents

<!--

Link to related tasks and documents, for instance, https://vivid-planet.atlassian.net/browse/COM-XXX.

MAKE SURE THAT EVERYTHING REQUIRED TO UNDERSTAND YOUR CHANGE IS IN THE PR DESCRIPTION.
Reviewers shouldn't need to review tasks, JIRA conversations etc. to understand what you're doing.

-->

## Open TODOs/questions

<!--

-   [ ] Need to validate that this actually works
-   [ ] Merge parent PR

-->

## Further information

<!--

Further information that helps reviewing the PR, for instance:
-   Alternative solutions you have considered
-   Dependent PRs
-   Links to relevant documentation, blog posts etc.

-->
