### PR TITLE
Fix pass scope to test email campaign form

### DIFF
--- a/.changeset/polite-keys-sell.md
+++ b/.changeset/polite-keys-sell.md
@@ -1,0 +1,5 @@
+---
+"@comet/brevo-admin": patch
+---
+
+Pass `scope` to `TestEmailCampaignForm`

--- a/packages/admin/src/emailCampaigns/form/EmailCampaignForm.tsx
+++ b/packages/admin/src/emailCampaigns/form/EmailCampaignForm.tsx
@@ -299,7 +299,7 @@ export function EmailCampaignForm({ id, EmailCampaignContentBlock, scope }: Form
                                         isSendable={!hasChanges && state.targetGroups != undefined}
                                         id={id}
                                     />
-                                    <TestEmailCampaignForm id={id} isSendable={!hasChanges && state.targetGroups != undefined} />
+                                    <TestEmailCampaignForm id={id} isSendable={!hasChanges && state.targetGroups != undefined} scope={scope} />
                                 </BlocksFinalForm>
                             ),
                         },

--- a/packages/admin/src/emailCampaigns/form/TestEmailCampaignForm.tsx
+++ b/packages/admin/src/emailCampaigns/form/TestEmailCampaignForm.tsx
@@ -2,7 +2,7 @@ import { gql, useApolloClient, useQuery } from "@apollo/client";
 import { Field, FinalForm, FinalFormSelect, SaveButton } from "@comet/admin";
 import { Newsletter } from "@comet/admin-icons";
 import { AdminComponentPaper, AdminComponentSectionGroup } from "@comet/blocks-admin";
-import { useContentScope } from "@comet/cms-admin";
+import { ContentScopeInterface } from "@comet/cms-admin";
 import { Card } from "@mui/material";
 import React from "react";
 import { FormattedMessage } from "react-intl";
@@ -18,6 +18,7 @@ interface FormProps {
 interface TestEmailCampaignFormProps {
     id?: string;
     isSendable?: boolean;
+    scope: ContentScopeInterface;
 }
 
 const brevoTestContactsSelectFragment = gql`
@@ -39,9 +40,8 @@ const brevoTestContactsSelectQuery = gql`
     ${brevoTestContactsSelectFragment}
 `;
 
-export const TestEmailCampaignForm = ({ id, isSendable = false }: TestEmailCampaignFormProps) => {
+export const TestEmailCampaignForm = ({ id, isSendable = false, scope }: TestEmailCampaignFormProps) => {
     const client = useApolloClient();
-    const scope = useContentScope();
 
     // Contact creation is limited to 100 at a time. Therefore, 100 contacts are queried without using pagination.
     const { data, loading, error } = useQuery(brevoTestContactsSelectQuery, {


### PR DESCRIPTION
## Description

Pass scope correctly to `TestEmailCampaignForm`

<!--

Everything below this is intended to help ease reviewing this PR.
Remove all unrelated sections.

-->

## Example

<!--

Make sure to provide an example of your change if your change includes a new API.

This can be either:
-   The implementation in Demo
-   A unit test

--->

[x] I have verified if my change requires an example

## Screenshots/screencasts

<!--

When making a visual change, please provide either screenshots or screencasts.

Hint: For before/after views, you can use a table:

| Before   | After   |
| -------- | ------- |
| Link     | Link    |

-->

## Changeset

<!--

When making a notable change, make sure to add a changeset.
See [CONTRIBUTING.md](https://github.com/vivid-planet/comet/blob/HEAD/CONTRIBUTING.md) for more information.

TL;DR

Add a changeset when:
-   changing the package's public API (`src/index.ts`)
-   fixing a bug
-   making a visual change

Changeset writing guidelines:
-   Use active voice: "Add new thing" vs. "A new thing is added"
-   First line should be the title: "Add new alert component"
-   Provide additional information in the description
-   Use backticks to highlight code: Add new `Alert` component
-   Use bold formatting for "headlines" in the description: **Example**

--->

[x] I have verified if my change requires a changeset

## Related tasks and documents

<!--

Link to related tasks and documents, for instance, https://vivid-planet.atlassian.net/browse/COM-XXX.

MAKE SURE THAT EVERYTHING REQUIRED TO UNDERSTAND YOUR CHANGE IS IN THE PR DESCRIPTION.
Reviewers shouldn't need to review tasks, JIRA conversations etc. to understand what you're doing.

-->

## Open TODOs/questions

<!--

-   [ ] Need to validate that this actually works
-   [ ] Merge parent PR

-->

## Further information

<!--

Further information that helps reviewing the PR, for instance:
-   Alternative solutions you have considered
-   Dependent PRs
-   Links to relevant documentation, blog posts etc.

-->
