### PR TITLE
Fix brevo config migrations

### DIFF
--- a/.changeset/selfish-years-think.md
+++ b/.changeset/selfish-years-think.md
@@ -1,0 +1,7 @@
+---
+"@comet/brevo-api": patch
+---
+
+Remove `scope` from `BrevoConfig` database migration in module
+
+Add database migration for adding individual `scope` columns to `BrevoConfig` instead.

--- a/.changeset/selfish-years-think.md
+++ b/.changeset/selfish-years-think.md
@@ -4,4 +4,4 @@
 
 Remove `scope` from `BrevoConfig` database migration in module
 
-Add database migration for adding individual `scope` columns to `BrevoConfig` instead.
+A custom database migration must be created in the project to add individual `scope` columns to `BrevoConfig`.

--- a/demo/api/src/db/migrations/Migration20250221074620.ts
+++ b/demo/api/src/db/migrations/Migration20250221074620.ts
@@ -1,0 +1,11 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20250221074620 extends Migration {
+    // this migration needs to be generated manually
+    async up(): Promise<void> {
+        this.addSql(
+            `alter table "BrevoConfig" add column "scope_domain" text not null default 'main', add column "scope_language" text not null default 'en';`,
+        );
+        this.addSql(`alter table "BrevoConfig" alter column "scope_domain" drop default, alter column "scope_language" drop default;`);
+    }
+}

--- a/packages/api/src/mikro-orm/migrations/Migration20250221073825.ts
+++ b/packages/api/src/mikro-orm/migrations/Migration20250221073825.ts
@@ -1,0 +1,7 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20250221073825 extends Migration {
+    async up(): Promise<void> {
+        this.addSql('alter table "BrevoConfig" drop column "scope_domain", drop column "scope_language";');
+    }
+}

--- a/packages/api/src/mikro-orm/migrations/migrations.ts
+++ b/packages/api/src/mikro-orm/migrations/migrations.ts
@@ -14,6 +14,7 @@ import { Migration20241018110515 } from "./Migration20241018110515";
 import { Migration20241022144400 } from "./Migration20241022144400";
 import { Migration20241024071748 } from "./Migration20241024071748";
 import { Migration20241119101706 } from "./Migration20241119101706";
+import { Migration20250221073825 } from "./Migration20250221073825";
 
 export const migrationsList: MigrationObject[] = [
     { name: "Migration20240115095733", class: Migration20240115095733 },
@@ -30,4 +31,5 @@ export const migrationsList: MigrationObject[] = [
     { name: "Migration20241119101706", class: Migration20241119101706 },
     { name: "Migration20241022144400", class: Migration20241022144400 },
     { name: "Migration20241024071748", class: Migration20241024071748 },
+    { name: "Migration20250221073825", class: Migration20250221073825 },
 ];


### PR DESCRIPTION
Columns for `scope` were added to the `BrevoConfig` table. This lead to bugs in projects, as scopes are configured differently. Therefor the columns `scope_domain` and `scope_language` were dropped and need to be added with a migration in the project instead.