### PR TITLE
Allow adding contacts without doi manually

### DIFF
--- a/.changeset/shaggy-deers-doubt.md
+++ b/.changeset/shaggy-deers-doubt.md
@@ -1,0 +1,6 @@
+---
+"@comet/brevo-admin": minor
+"@comet/brevo-api": minor
+---
+
+Enable creating contacts manually with the contact form in admin without sending a double opt-in mail

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -981,6 +981,7 @@ input BrevoContactInput {
   email: String!
   blocked: Boolean!
   redirectionUrl: String!
+  sendDoubleOptIn: Boolean! = true
   attributes: BrevoContactAttributesInput
 }
 

--- a/packages/admin/src/brevoContacts/form/BrevoContactForm.tsx
+++ b/packages/admin/src/brevoContacts/form/BrevoContactForm.tsx
@@ -1,6 +1,7 @@
 import { DocumentNode, gql, useApolloClient, useQuery } from "@apollo/client";
 import {
     Alert,
+    CheckboxField,
     FinalForm,
     FinalFormSaveButton,
     FinalFormSubmitEvent,
@@ -80,6 +81,7 @@ export function BrevoContactForm({ id, scope, input2State, additionalFormFields,
         let baseInitialValues = {
             email: "",
             redirectionUrl: "",
+            sendDoubleOptIn: true,
         };
 
         if (input2State) {
@@ -184,21 +186,16 @@ export function BrevoContactForm({ id, scope, input2State, additionalFormFields,
                         </ToolbarActions>
                     </Toolbar>
                     <MainContent>
-                        <Box sx={{ marginBottom: 4 }}>
-                            <Alert severity="warning">
-                                {mode === "edit" ? (
+                        {mode === "edit" && (
+                            <Box sx={{ marginBottom: 4 }}>
+                                <Alert severity="warning">
                                     <FormattedMessage
                                         id="cometBrevoModule.brevoContact.contactEditAlert"
                                         defaultMessage="Editing a contact will affect all scopes and the target groups within those scopes."
                                     />
-                                ) : (
-                                    <FormattedMessage
-                                        id="cometBrevoModule.brevoContact.contactAddAlert"
-                                        defaultMessage="The contact will get a double opt-in email to confirm the subscription. After the contact's confirmation, the contact will be added to the corresponding target groups in this scope depending on the contact's attributes. Before the confirmation the contact will not be shown on the contacts page."
-                                    />
-                                )}
-                            </Alert>
-                        </Box>
+                                </Alert>
+                            </Box>
+                        )}
                         <TextField
                             required
                             fullWidth
@@ -207,17 +204,49 @@ export function BrevoContactForm({ id, scope, input2State, additionalFormFields,
                             disabled={mode === "edit"}
                         />
                         {mode === "add" && (
-                            <TextField
-                                required
-                                fullWidth
-                                name="redirectionUrl"
-                                label={
-                                    <FormattedMessage
-                                        id="cometBrevoModule.brevoContact.redirectionUrl"
-                                        defaultMessage="Redirection Url (Contact will be redirected to this page after the confirmation in the double opt-in email)"
+                            <Card sx={{ padding: 4, marginBottom: 5 }}>
+                                <FormSection
+                                    title={<FormattedMessage id="cometBrevoModule.brevoContact.doubleOptIn" defaultMessage="Double Opt-in" />}
+                                >
+                                    <CheckboxField
+                                        name="sendDoubleOptIn"
+                                        label={
+                                            <FormattedMessage
+                                                id="cometBrevoModule.brevoContact.sendDoubleOptInMail"
+                                                defaultMessage="Send double opt-in email"
+                                            />
+                                        }
+                                        fullWidth
                                     />
-                                }
-                            />
+                                    {values.sendDoubleOptIn ? (
+                                        <Alert severity="warning" sx={{ marginBottom: 5 }}>
+                                            <FormattedMessage
+                                                id="cometBrevoModule.brevoContact.contactAddAlert"
+                                                defaultMessage="The contact will get a double opt-in email to confirm the subscription. After the contact's confirmation, the contact will be added to the corresponding target groups in this scope depending on the contact's attributes. Before the confirmation the contact will not be shown on the contacts page."
+                                            />
+                                        </Alert>
+                                    ) : (
+                                        <Alert severity="error" sx={{ marginBottom: 5 }}>
+                                            <FormattedMessage
+                                                id="cometBrevoModule.brevoContact.contactNoOptInAlert"
+                                                defaultMessage="No Double Opt-In email will be sent. Please ensure that recipients have given their consent before proceeding"
+                                            />
+                                        </Alert>
+                                    )}
+
+                                    <TextField
+                                        disabled={values.sendDoubleOptIn ? false : true}
+                                        fullWidth
+                                        name="redirectionUrl"
+                                        label={
+                                            <FormattedMessage
+                                                id="cometBrevoModule.brevoContact.redirectionUrl"
+                                                defaultMessage="Redirection Url (Contact will be redirected to this page after the confirmation in the double opt-in email)"
+                                            />
+                                        }
+                                    />
+                                </FormSection>
+                            </Card>
                         )}
                         {additionalFormFields && (
                             <Card sx={{ padding: 4 }}>

--- a/packages/admin/src/brevoContacts/form/BrevoContactForm.tsx
+++ b/packages/admin/src/brevoContacts/form/BrevoContactForm.tsx
@@ -229,7 +229,9 @@ export function BrevoContactForm({ id, scope, input2State, additionalFormFields,
                                         <Alert severity="error" sx={{ marginBottom: 5 }}>
                                             <FormattedMessage
                                                 id="cometBrevoModule.brevoContact.contactNoOptInAlert"
-                                                defaultMessage="No Double Opt-In email will be sent. Please ensure that recipients have given their consent before proceeding"
+                                                defaultMessage="No Double Opt-In email will be sent. You are responsible for ensuring that recipients have provided their consent before proceeding. If consent has not been given, sending a Double Opt-In email is legally required.
+                                                
+                                                Additionally, the creation of the user will be tracked, and you may need to provide clarification if users report any issues."
                                             />
                                         </Alert>
                                     )}

--- a/packages/api/schema.gql
+++ b/packages/api/schema.gql
@@ -347,6 +347,7 @@ input BrevoContactInput {
   email: String!
   blocked: Boolean!
   redirectionUrl: String!
+  sendDoubleOptIn: Boolean! = true
 }
 
 input BrevoTestContactInput {

--- a/packages/api/src/brevo-api/brevo-api-contact.service.ts
+++ b/packages/api/src/brevo-api/brevo-api-contact.service.ts
@@ -74,11 +74,13 @@ export class BrevoApiContactsService {
     public async createBrevoContactWithoutDoubleOptIn(
         { email, attributes }: Brevo.CreateContact,
         brevoIds: number[],
+        templateId: number,
         scope: EmailCampaignScopeInterface,
     ): Promise<boolean> {
         const contact = {
             email,
             listIds: brevoIds,
+            templateId,
             attributes,
         };
         const { response } = await this.getContactsApi(scope).createContact(contact);

--- a/packages/api/src/brevo-api/brevo-api-contact.service.ts
+++ b/packages/api/src/brevo-api/brevo-api-contact.service.ts
@@ -74,14 +74,12 @@ export class BrevoApiContactsService {
     public async createBrevoContactWithoutDoubleOptIn(
         { email, attributes }: Brevo.CreateContact,
         brevoIds: number[],
-        templateId: number,
         scope: EmailCampaignScopeInterface,
     ): Promise<boolean> {
         const contact = {
             email,
             listIds: brevoIds,
             attributes,
-            templateId,
         };
         const { response } = await this.getContactsApi(scope).createContact(contact);
 

--- a/packages/api/src/brevo-api/brevo-api-contact.service.ts
+++ b/packages/api/src/brevo-api/brevo-api-contact.service.ts
@@ -14,7 +14,7 @@ import { BrevoApiContactList } from "./dto/brevo-api-contact-list";
 export interface CreateDoubleOptInContactData {
     email: string;
     attributes?: BrevoContactAttributesInterface;
-    redirectionUrl: string;
+    redirectionUrl?: string;
 }
 
 @Injectable()
@@ -53,19 +53,39 @@ export class BrevoApiContactsService {
         scope: EmailCampaignScopeInterface,
     ): Promise<boolean> {
         try {
-            const contact = {
-                email,
-                includeListIds: brevoIds,
-                templateId,
-                redirectionUrl,
-                attributes,
-            };
-            const { response } = await this.getContactsApi(scope).createDoiContact(contact);
+            if (redirectionUrl) {
+                const contact = {
+                    email,
+                    includeListIds: brevoIds,
+                    templateId,
+                    redirectionUrl,
+                    attributes,
+                };
+                const { response } = await this.getContactsApi(scope).createDoiContact(contact);
 
-            return response.statusCode === 204 || response.statusCode === 201;
+                return response.statusCode === 204 || response.statusCode === 201;
+            }
+            return false;
         } catch (error) {
             handleBrevoError(error);
         }
+    }
+
+    public async createBrevoContactWithoutDoubleOptIn(
+        { email, attributes }: Brevo.CreateContact,
+        brevoIds: number[],
+        templateId: number,
+        scope: EmailCampaignScopeInterface,
+    ): Promise<boolean> {
+        const contact = {
+            email,
+            listIds: brevoIds,
+            attributes,
+            templateId,
+        };
+        const { response } = await this.getContactsApi(scope).createContact(contact);
+
+        return response.statusCode === 204 || response.statusCode === 201;
     }
 
     public async createTestContact(

--- a/packages/api/src/brevo-contact/brevo-contact-import.service.ts
+++ b/packages/api/src/brevo-contact/brevo-contact-import.service.ts
@@ -154,11 +154,12 @@ export class BrevoContactImportService {
             } else if (!brevoContact) {
                 const brevoConfig = await this.brevoConfigRepository.findOneOrFail({ scope });
 
-                const success = await this.brevoContactsService.createDoubleOptInContact({
+                const success = await this.brevoContactsService.createContact({
                     ...contact,
                     scope,
                     templateId: brevoConfig.doubleOptInTemplateId,
                     listIds: [mainTargetGroupForScope.brevoId, ...targetGroupBrevoIds],
+                    sendDoubleOptIn: true,
                 });
                 if (success) return "created";
             }

--- a/packages/api/src/brevo-contact/brevo-contact.resolver.ts
+++ b/packages/api/src/brevo-contact/brevo-contact.resolver.ts
@@ -215,12 +215,13 @@ export function createBrevoContactResolver({
 
             const brevoConfig = await this.brevoConfigRepository.findOneOrFail({ scope });
 
-            const created = await this.brevoContactsService.createDoubleOptInContact({
+            const created = await this.brevoContactsService.createContact({
                 email: input.email,
                 attributes: input.attributes,
                 redirectionUrl: input.redirectionUrl,
                 scope,
                 templateId: brevoConfig.doubleOptInTemplateId,
+                sendDoubleOptIn: input.sendDoubleOptIn,
             });
 
             if (created) {

--- a/packages/api/src/brevo-contact/brevo-contacts.service.ts
+++ b/packages/api/src/brevo-contact/brevo-contacts.service.ts
@@ -50,7 +50,7 @@ export class BrevoContactsService {
         }
 
         if (!sendDoubleOptIn) {
-            created = await this.brevoContactsApiService.createBrevoContactWithoutDoubleOptIn({ email, attributes }, brevoIds, templateId, scope);
+            created = await this.brevoContactsApiService.createBrevoContactWithoutDoubleOptIn({ email, attributes }, brevoIds, scope);
         } else {
             created = await this.brevoContactsApiService.createDoubleOptInBrevoContact(
                 { email, redirectionUrl, attributes },

--- a/packages/api/src/brevo-contact/brevo-contacts.service.ts
+++ b/packages/api/src/brevo-contact/brevo-contacts.service.ts
@@ -50,7 +50,7 @@ export class BrevoContactsService {
         }
 
         if (!sendDoubleOptIn) {
-            created = await this.brevoContactsApiService.createBrevoContactWithoutDoubleOptIn({ email, attributes }, brevoIds, scope);
+            created = await this.brevoContactsApiService.createBrevoContactWithoutDoubleOptIn({ email, attributes }, brevoIds, templateId, scope);
         } else {
             created = await this.brevoContactsApiService.createDoubleOptInBrevoContact(
                 { email, redirectionUrl, attributes },

--- a/packages/api/src/brevo-contact/dto/brevo-contact-input.factory.ts
+++ b/packages/api/src/brevo-contact/dto/brevo-contact-input.factory.ts
@@ -11,7 +11,8 @@ export interface BrevoContactInputInterface {
     email: string;
     blocked?: boolean;
     attributes?: BrevoContactAttributesInterface;
-    redirectionUrl: string;
+    redirectionUrl?: string;
+    sendDoubleOptIn: boolean;
 }
 
 export interface BrevoContactUpdateInputInterface {
@@ -44,7 +45,13 @@ export class BrevoContactInputFactory {
             @Field()
             @IsUrl({ require_tld: process.env.NODE_ENV === "production" })
             @IsValidRedirectURL(Scope)
-            redirectionUrl: string;
+            @IsUndefinable()
+            redirectionUrl?: string;
+
+            @IsNotEmpty()
+            @IsBoolean()
+            @Field({ defaultValue: true })
+            sendDoubleOptIn: boolean;
         }
 
         @InputType({


### PR DESCRIPTION
## Description

It should be possible to create contacts manually with the contact form in the admin, without sending a double opt-in mail: 

- Add a field "sendDoubleOptIn" (default: true) 
- Add an alert if "sendDoubleOptIn" is set to false and refactor ContactForm
- Set redirectionUrl to nullable, as it is not required, if no DOI is sent
- Refactor api functionality to differentiate between contacts with and without DOI

This PR only handles manually added contacts. Imported contacts will be handled in an upcoming PR.

## Screenshots/screencasts

<img width="1679" alt="Screenshot 2025-03-12 at 08 50 54" src="https://github.com/user-attachments/assets/4f08a474-f353-4966-9eb5-f1765361b65c" />
<img width="1678" alt="Screenshot 2025-03-12 at 08 51 02" src="https://github.com/user-attachments/assets/be9b027e-f3d6-4f26-a296-bbe09f194186" />


## Changeset

[x] I have verified if my change requires a changeset

## Related tasks and documents

https://vivid-planet.atlassian.net/browse/XXXL-969
