### PR TITLE
Deprecate `scopeParts` in `createBrevoTestContactsPage` and use scopeParts from the BrevoConfig instead

### DIFF
--- a/.changeset/mean-zebras-tie.md
+++ b/.changeset/mean-zebras-tie.md
@@ -1,0 +1,7 @@
+---
+"@comet/brevo-admin": patch
+---
+
+Deprecate `scopeParts` in `createBrevoTestContactsPage` and use scopeParts from the BrevoConfig instead
+
+Instead, the `scopeParts` from the BrevoConfig will be used. This is in line with the other Page factories.

--- a/demo/admin/src/common/MasterMenu.tsx
+++ b/demo/admin/src/common/MasterMenu.tsx
@@ -64,7 +64,6 @@ const getMasterMenuData = ({ brevoContactConfig }: { brevoContactConfig: BrevoCo
     });
 
     const BrevoTestContactsPage = createBrevoTestContactsPage({
-        scopeParts: ["domain", "language"],
         additionalAttributesFragment: brevoContactConfig.additionalAttributesFragment,
         additionalGridFields: brevoContactConfig.additionalGridFields,
         additionalFormFields: brevoContactConfig.additionalFormFields,

--- a/packages/admin/src/brevoTestContacts/BrevoTestContactsPage.tsx
+++ b/packages/admin/src/brevoTestContacts/BrevoTestContactsPage.tsx
@@ -4,11 +4,13 @@ import { DocumentNode } from "graphql";
 import * as React from "react";
 import { useIntl } from "react-intl";
 
+import { useBrevoConfig } from "../common/BrevoConfigProvider";
 import { BrevoTestContactsGrid } from "./BrevoTestContactsGrid";
 import { BrevoTestContactForm, EditBrevoContactFormValues } from "./form/BrevoTestContactForm";
 
 interface CreateContactsPageOptions {
-    scopeParts: string[];
+    /** @deprecated Pass via BrevoConfigProvider instead */
+    scopeParts?: string[];
     additionalAttributesFragment?: { name: string; fragment: DocumentNode };
     additionalGridFields?: GridColDef[];
     additionalFormFields?: React.ReactNode;
@@ -16,7 +18,7 @@ interface CreateContactsPageOptions {
 }
 
 function createBrevoTestContactsPage({
-    scopeParts,
+    scopeParts: passedScopeParts,
     additionalAttributesFragment,
     additionalFormFields,
     additionalGridFields,
@@ -24,6 +26,8 @@ function createBrevoTestContactsPage({
 }: CreateContactsPageOptions) {
     function BrevoTestContactsPage(): JSX.Element {
         const intl = useIntl();
+        const brevoConfig = useBrevoConfig();
+        const scopeParts = passedScopeParts ?? brevoConfig.scopeParts;
         const { scope: completeScope } = useContentScope();
 
         const scope = scopeParts.reduce((acc, scopePart) => {


### PR DESCRIPTION
Deprecate `scopeParts` in `createBrevoTestContactsPage` and use scopeParts from the BrevoConfig instead

Instead, the `scopeParts` from the BrevoConfig will be used. This is in line with the other Page factories.