### PR TITLE
Hash emails in import logs

### DIFF
--- a/packages/api/src/blacklisted-contacts/blacklisted-contacts.service.ts
+++ b/packages/api/src/blacklisted-contacts/blacklisted-contacts.service.ts
@@ -2,10 +2,10 @@ import { EntityManager, EntityRepository } from "@mikro-orm/core";
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { Inject, Injectable } from "@nestjs/common";
 import { EmailCampaignScopeInterface } from "src/types";
-import { hashEmail } from "src/util/hash.util";
 
 import { BrevoModuleConfig } from "../config/brevo-module.config";
 import { BREVO_MODULE_CONFIG } from "../config/brevo-module.constants";
+import { hashEmail } from "../util/hash.util";
 import { BlacklistedContactsInterface } from "./entity/blacklisted-contacts.entity.factory";
 
 @Injectable()

--- a/packages/api/src/brevo-contact/brevo-contacts.service.ts
+++ b/packages/api/src/brevo-contact/brevo-contacts.service.ts
@@ -2,7 +2,6 @@ import { EntityRepository } from "@mikro-orm/core";
 import { InjectRepository } from "@mikro-orm/nestjs";
 import { Inject, Injectable } from "@nestjs/common";
 import { BrevoConfigInterface } from "src/brevo-config/entities/brevo-config-entity.factory";
-import { hashEmail } from "src/util/hash.util";
 
 import { BlacklistedContactsInterface } from "../blacklisted-contacts/entity/blacklisted-contacts.entity.factory";
 import { BrevoApiContactsService } from "../brevo-api/brevo-api-contact.service";
@@ -12,6 +11,7 @@ import { BrevoModuleConfig } from "../config/brevo-module.config";
 import { BREVO_MODULE_CONFIG } from "../config/brevo-module.constants";
 import { TargetGroupsService } from "../target-group/target-groups.service";
 import { BrevoContactAttributesInterface, EmailCampaignScopeInterface } from "../types";
+import { hashEmail } from "../util/hash.util";
 import { BrevoContactInterface } from "./dto/brevo-contact.factory";
 import { SubscribeInputInterface } from "./dto/subscribe-input.factory";
 import { SubscribeResponse } from "./dto/subscribe-response.enum";

--- a/packages/api/src/brevo-email-import-log/brevo-email-import-log.service.ts
+++ b/packages/api/src/brevo-email-import-log/brevo-email-import-log.service.ts
@@ -10,7 +10,6 @@ import { BrevoEmailImportLogInterface, ContactSource } from "./entity/brevo-emai
 
 @Injectable()
 export class BrevoEmailImportLogService {
-    private readonly secretKey: string;
     constructor(
         @Inject(BREVO_MODULE_CONFIG) private readonly config: BrevoModuleConfig,
         @InjectRepository("BrevoEmailImportLog") private readonly repository: EntityRepository<BrevoEmailImportLogInterface>,

--- a/packages/api/src/brevo-email-import-log/brevo-email-import-log.service.ts
+++ b/packages/api/src/brevo-email-import-log/brevo-email-import-log.service.ts
@@ -1,16 +1,23 @@
 import { EntityManager, EntityRepository } from "@mikro-orm/core";
 import { InjectRepository } from "@mikro-orm/nestjs";
-import { Injectable } from "@nestjs/common";
+import { Inject, Injectable } from "@nestjs/common";
 import { EmailCampaignScopeInterface } from "src/types";
 
+import { BrevoModuleConfig } from "../config/brevo-module.config";
+import { BREVO_MODULE_CONFIG } from "../config/brevo-module.constants";
+import { hashEmail } from "../util/hash.util";
 import { BrevoEmailImportLogInterface, ContactSource } from "./entity/brevo-email-import-log.entity.factory";
 
 @Injectable()
 export class BrevoEmailImportLogService {
+    private readonly secretKey: string;
     constructor(
+        @Inject(BREVO_MODULE_CONFIG) private readonly config: BrevoModuleConfig,
         @InjectRepository("BrevoEmailImportLog") private readonly repository: EntityRepository<BrevoEmailImportLogInterface>,
         private readonly entityManager: EntityManager,
-    ) {}
+    ) {
+        this.secretKey = this.config.emailHashKey;
+    }
     public async addContactToLogs(
         email: string,
         responsibleUserId: string,
@@ -19,7 +26,7 @@ export class BrevoEmailImportLogService {
         importId?: string,
     ): Promise<BrevoEmailImportLogInterface> {
         const log = this.repository.create({
-            importedEmail: email,
+            importedEmail: hashEmail(email, this.secretKey),
             responsibleUserId,
             scope,
             createdAt: new Date(),

--- a/packages/api/src/brevo-email-import-log/brevo-email-import-log.service.ts
+++ b/packages/api/src/brevo-email-import-log/brevo-email-import-log.service.ts
@@ -15,9 +15,7 @@ export class BrevoEmailImportLogService {
         @Inject(BREVO_MODULE_CONFIG) private readonly config: BrevoModuleConfig,
         @InjectRepository("BrevoEmailImportLog") private readonly repository: EntityRepository<BrevoEmailImportLogInterface>,
         private readonly entityManager: EntityManager,
-    ) {
-        this.secretKey = this.config.emailHashKey;
-    }
+    ) {}
     public async addContactToLogs(
         email: string,
         responsibleUserId: string,
@@ -26,7 +24,7 @@ export class BrevoEmailImportLogService {
         importId?: string,
     ): Promise<BrevoEmailImportLogInterface> {
         const log = this.repository.create({
-            importedEmail: hashEmail(email, this.secretKey),
+            importedEmail: hashEmail(email, this.config.emailHashKey),
             responsibleUserId,
             scope,
             createdAt: new Date(),


### PR DESCRIPTION
- To avoid storing personal data, emails are hashed before saving them to the import logs.
- Correct import of hashEmail function

