### PR TITLE
Fix double opt in query by adding scope parameter

### DIFF
--- a/.changeset/brown-moons-clap.md
+++ b/.changeset/brown-moons-clap.md
@@ -1,0 +1,12 @@
+---
+"@comet/brevo-admin": patch
+"@comet/brevo-api": patch
+---
+
+Fix scope parameter handling in `doubleOptInTemplates` query
+
+Previously, the `scope` parameter in the `doubleOptInTemplates` query was not properly handled, causing it to always resolve to `undefined`. This update:
+
+-   Adds proper scope parameter handling in the API
+-   Implements scope parameter passing from the admin interface
+-   Ensures correct template filtering based on scope

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -608,7 +608,7 @@ type Query {
   targetGroup(id: ID!): TargetGroup!
   targetGroups(scope: EmailCampaignContentScopeInput!, search: String, filter: TargetGroupFilter, sort: [TargetGroupSort!], offset: Int! = 0, limit: Int! = 25): PaginatedTargetGroups!
   senders(scope: EmailCampaignContentScopeInput!): [BrevoApiSender!]
-  doubleOptInTemplates: [BrevoApiEmailTemplate!]
+  doubleOptInTemplates(scope: EmailCampaignContentScopeInput!): [BrevoApiEmailTemplate!]
   brevoConfig(scope: EmailCampaignContentScopeInput!): BrevoConfig
 }
 

--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -150,12 +150,14 @@ export class AppModule {
                                     apiKey: config.brevo.apiKey,
                                     redirectUrlForImport: config.brevo.redirectUrlForImport,
                                 };
-                            } else {
+                            } else if (scope.domain === "secondary") {
                                 return {
                                     apiKey: config.brevo.apiKey,
                                     redirectUrlForImport: config.brevo.redirectUrlForImport,
                                 };
                             }
+
+                            throw Error("Invalid Scope passed");
                         },
                         BrevoContactAttributes,
                         BrevoContactFilterAttributes,

--- a/demo/api/src/app.module.ts
+++ b/demo/api/src/app.module.ts
@@ -157,7 +157,7 @@ export class AppModule {
                                 };
                             }
 
-                            throw Error("Invalid Scope passed");
+                            throw Error("Invalid scope passed");
                         },
                         BrevoContactAttributes,
                         BrevoContactFilterAttributes,

--- a/packages/admin/src/brevoConfiguration/BrevoConfigForm.gql.ts
+++ b/packages/admin/src/brevoConfiguration/BrevoConfigForm.gql.ts
@@ -63,8 +63,8 @@ export const sendersSelectQuery = gql`
 `;
 
 export const doubleOptInTemplatesSelectQuery = gql`
-    query DoubleOptInTemplatesSelect {
-        doubleOptInTemplates {
+    query DoubleOptInTemplatesSelect($scope: EmailCampaignContentScopeInput!) {
+        doubleOptInTemplates(scope: $scope) {
             id
             name
         }

--- a/packages/admin/src/brevoConfiguration/BrevoConfigForm.tsx
+++ b/packages/admin/src/brevoConfiguration/BrevoConfigForm.tsx
@@ -92,7 +92,9 @@ export function BrevoConfigForm({ scope }: FormProps): React.ReactElement {
         data: doubleOptInTemplatesData,
         error: doubleOptInTemplatesError,
         loading: doubleOptInTemplatesLoading,
-    } = useQuery<GQLDoubleOptInTemplatesSelectQuery, GQLDoubleOptInTemplatesSelectQueryVariables>(doubleOptInTemplatesSelectQuery);
+    } = useQuery<GQLDoubleOptInTemplatesSelectQuery, GQLDoubleOptInTemplatesSelectQueryVariables>(doubleOptInTemplatesSelectQuery, {
+        variables: { scope },
+    });
 
     const senderOptions =
         sendersData?.senders?.map((sender) => ({

--- a/packages/api/schema.gql
+++ b/packages/api/schema.gql
@@ -230,7 +230,7 @@ type Query {
   emailCampaigns(scope: EmailCampaignContentScopeInput!, search: String, filter: EmailCampaignFilter, sort: [EmailCampaignSort!], offset: Int! = 0, limit: Int! = 25): PaginatedEmailCampaigns!
   emailCampaignStatistics(id: ID!): BrevoApiCampaignStatistics
   senders(scope: EmailCampaignContentScopeInput!): [BrevoApiSender!]
-  doubleOptInTemplates: [BrevoApiEmailTemplate!]
+  doubleOptInTemplates(scope: EmailCampaignContentScopeInput!): [BrevoApiEmailTemplate!]
   brevoConfig(scope: EmailCampaignContentScopeInput!): BrevoConfig
 }
 

--- a/packages/api/src/brevo-config/brevo-config.resolver.ts
+++ b/packages/api/src/brevo-config/brevo-config.resolver.ts
@@ -73,8 +73,11 @@ export function createBrevoConfigResolver({
 
         @RequiredPermission(["brevo-newsletter-config"], { skipScopeCheck: true })
         @Query(() => [BrevoApiEmailTemplate], { nullable: true })
-        async doubleOptInTemplates(): Promise<Array<BrevoApiEmailTemplate> | undefined> {
-            const { templates } = await this.brevoTransactionalEmailsApiService.getEmailTemplates(Scope);
+        async doubleOptInTemplates(
+            @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope))
+            scope: typeof Scope,
+        ): Promise<Array<BrevoApiEmailTemplate> | undefined> {
+            const { templates } = await this.brevoTransactionalEmailsApiService.getEmailTemplates(scope);
             const doubleOptInTemplates = templates?.filter((template) => template.tag === "optin" && template.isActive);
             return doubleOptInTemplates;
         }


### PR DESCRIPTION
## Description

The Double-Opt In Request had no scope parameter but instead passed the class. This meant always passing undefined.

Now the query sends the scope parameter:
![Screenshot 2025-04-16 at 10 22 43](https://github.com/user-attachments/assets/c07e6652-9b91-41dc-b7df-2a0fb712f4fb)

## Changeset

[x] I have verified if my change requires a changeset

