### PR TITLE
Fix height of block preview in campaign view

### DIFF
--- a/.changeset/soft-trains-walk.md
+++ b/.changeset/soft-trains-walk.md
@@ -1,0 +1,5 @@
+---
+"@comet/brevo-admin": patch
+---
+
+Fix block preview being too small on view page of already sent campaings

--- a/packages/admin/src/emailCampaigns/view/EmailCampaignView.tsx
+++ b/packages/admin/src/emailCampaigns/view/EmailCampaignView.tsx
@@ -64,7 +64,7 @@ export function EmailCampaignView({ id, EmailCampaignContentBlock }: EmailCampai
                 </ToolbarTitleItem>
                 <ToolbarFillSpace />
             </Toolbar>
-            <MainContent disablePaddingBottom>
+            <MainContent fullHeight>
                 <IFrameBridgeProvider key={previewUrl}>
                     <BlockPreview url={previewUrl} previewState={previewState} previewApi={previewApi} />
                 </IFrameBridgeProvider>


### PR DESCRIPTION
## Description

The block prview on the view page of already sent campaigns was too small. Probably caused by a comet update. Setting the `fullHeight` prop on the `MainContent` resolves the issue.  


## Screenshots/screencasts

| Before   | After   |
| -------- | ------- |
|  ![Screenshot 2025-05-27 at 14 41 32](https://github.com/user-attachments/assets/53be5aef-a754-44f1-a4d1-b6f86e7e5eb7) | ![Screenshot 2025-05-27 at 14 41 45](https://github.com/user-attachments/assets/f555b176-760b-47c0-91ee-e25ea6cc215b) |


## Related tasks and documents
Task: https://vivid-planet.atlassian.net/browse/XXXL-1090
