### PR TITLE
Revert updating-graphql-scalars

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -63,7 +63,7 @@
         "eslint": "^8.0.0",
         "express": "^4.21.2",
         "graphql": "^15.9.0",
-        "graphql-scalars": "1.24.2",
+        "graphql-scalars": "1.24.1",
         "jest": "^29.7.0",
         "jest-junit": "^15.0.0",
         "lodash.isequal": "^4.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1016,8 +1016,8 @@ importers:
         specifier: ^15.9.0
         version: 15.9.0
       graphql-scalars:
-        specifier: 1.24.2
-        version: 1.24.2(graphql@15.9.0)
+        specifier: 1.24.1
+        version: 1.24.1(graphql@15.9.0)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.15.27)(ts-node@10.9.2)
@@ -14265,16 +14265,6 @@ packages:
     dependencies:
       graphql: 15.9.0
       tslib: 2.8.1
-
-  /graphql-scalars@1.24.2(graphql@15.9.0):
-    resolution: {integrity: sha512-FoZ11yxIauEnH0E5rCUkhDXHVn/A6BBfovJdimRZCQlFCl+h7aVvarKmI15zG4VtQunmCDdqdtNs6ixThy3uAg==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-    dependencies:
-      graphql: 15.9.0
-      tslib: 2.8.1
-    dev: true
 
   /graphql-tag@2.12.6(graphql@15.9.0):
     resolution: {integrity: sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==}


### PR DESCRIPTION
## Description

Updating graphql-scalars did break the lint pipeline. This needs to be checked specifically. For now i just revert it to have a working lint pipeline again

TIMR: COM-1053
