### PR TITLE
Fix brevo config page

### DIFF
--- a/.changeset/shiny-mirrors-eat.md
+++ b/.changeset/shiny-mirrors-eat.md
@@ -1,0 +1,9 @@
+---
+"@comet/brevo-admin": patch
+"@comet/brevo-api": patch
+---
+
+Resolve Issues with Brevo Config Page Permissions
+
+-   Address a bug that required the brevo-newsletter-config permission to send email campaigns from the admin interface.
+-   Improve error handling by enhancing the styling and incorporating a MUI Alert component to clearly display messages when the configuration is missing.

--- a/demo/admin/src/common/MasterMenu.tsx
+++ b/demo/admin/src/common/MasterMenu.tsx
@@ -142,6 +142,7 @@ const getMasterMenuData = ({ brevoContactConfig }: { brevoContactConfig: BrevoCo
                         path: "/newsletter/config",
                         render: () => <BrevoConfigPage />,
                     },
+                    requiredPermission: "brevo-newsletter-config",
                 },
             ],
             requiredPermission: "brevo-newsletter",

--- a/demo/api/schema.gql
+++ b/demo/api/schema.gql
@@ -307,7 +307,7 @@ type PageTreeNode {
   scope: PageTreeNodeScope!
   category: PageTreeNodeCategory!
   childNodes: [PageTreeNode!]!
-  numberOfDescendants: Float!
+  numberOfDescendants: Int!
   parentNode: PageTreeNode
   path: String!
   parentNodes: [PageTreeNode!]!
@@ -610,6 +610,7 @@ type Query {
   targetGroups(scope: EmailCampaignContentScopeInput!, search: String, filter: TargetGroupFilter, sort: [TargetGroupSort!], offset: Int! = 0, limit: Int! = 25): PaginatedTargetGroups!
   senders(scope: EmailCampaignContentScopeInput!): [BrevoApiSender!]
   doubleOptInTemplates(scope: EmailCampaignContentScopeInput!): [BrevoApiEmailTemplate!]
+  isBrevoConfigDefined(scope: EmailCampaignContentScopeInput!): Boolean!
   brevoConfig(scope: EmailCampaignContentScopeInput!): BrevoConfig
 }
 

--- a/packages/admin/src/emailCampaigns/form/SendManagerWrapper.gql.ts
+++ b/packages/admin/src/emailCampaigns/form/SendManagerWrapper.gql.ts
@@ -1,9 +1,7 @@
 import { gql } from "@apollo/client";
 
 export const brevoConfigQuery = gql`
-    query BrevoConfig($scope: EmailCampaignContentScopeInput!) {
-        brevoConfig(scope: $scope) {
-            id
-        }
+    query IsBrevoConfigDefined($scope: EmailCampaignContentScopeInput!) {
+        isBrevoConfigDefined(scope: $scope)
     }
 `;

--- a/packages/admin/src/emailCampaigns/form/SendManagerWrapper.tsx
+++ b/packages/admin/src/emailCampaigns/form/SendManagerWrapper.tsx
@@ -1,12 +1,12 @@
 import { useQuery } from "@apollo/client";
-import { Loading } from "@comet/admin";
+import { Alert, Loading } from "@comet/admin";
 import { ContentScopeInterface } from "@comet/cms-admin";
 import { Typography } from "@mui/material";
 import * as React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { brevoConfigQuery } from "./SendManagerWrapper.gql";
-import { GQLBrevoConfigQuery, GQLBrevoConfigQueryVariables } from "./SendManagerWrapper.gql.generated";
+import { GQLIsBrevoConfigDefinedQuery, GQLIsBrevoConfigDefinedQueryVariables } from "./SendManagerWrapper.gql.generated";
 
 interface SendManagerWrapperProps {
     scope: ContentScopeInterface;
@@ -17,7 +17,7 @@ export const SendManagerWrapper = ({ scope, children }: React.PropsWithChildren<
         data: brevoConfig,
         loading,
         error,
-    } = useQuery<GQLBrevoConfigQuery, GQLBrevoConfigQueryVariables>(brevoConfigQuery, {
+    } = useQuery<GQLIsBrevoConfigDefinedQuery, GQLIsBrevoConfigDefinedQueryVariables>(brevoConfigQuery, {
         variables: { scope },
         fetchPolicy: "network-only",
     });
@@ -28,13 +28,15 @@ export const SendManagerWrapper = ({ scope, children }: React.PropsWithChildren<
 
     if (error) throw error;
 
-    if (brevoConfig?.brevoConfig?.id == undefined) {
+    if (brevoConfig?.isBrevoConfigDefined === false) {
         return (
             <Typography>
-                <FormattedMessage
-                    id="cometBrevoModule.emailCampaigns.missingConfig"
-                    defaultMessage="Missing brevo config! Configure brevo via the brevo config page."
-                />
+                <Alert severity="error">
+                    <FormattedMessage
+                        id="cometBrevoModule.emailCampaigns.configNotDefined"
+                        defaultMessage="Brevo configuration is not defined. Please ask an administrator to set it up before sending email campaigns."
+                    />
+                </Alert>
             </Typography>
         );
     }

--- a/packages/api/schema.gql
+++ b/packages/api/schema.gql
@@ -231,6 +231,7 @@ type Query {
   emailCampaignStatistics(id: ID!): BrevoApiCampaignStatistics
   senders(scope: EmailCampaignContentScopeInput!): [BrevoApiSender!]
   doubleOptInTemplates(scope: EmailCampaignContentScopeInput!): [BrevoApiEmailTemplate!]
+  isBrevoConfigDefined(scope: EmailCampaignContentScopeInput!): Boolean!
   brevoConfig(scope: EmailCampaignContentScopeInput!): BrevoConfig
 }
 

--- a/packages/api/src/brevo-config/brevo-config.resolver.ts
+++ b/packages/api/src/brevo-config/brevo-config.resolver.ts
@@ -82,6 +82,16 @@ export function createBrevoConfigResolver({
             return doubleOptInTemplates;
         }
 
+        @Query(() => Boolean)
+        @RequiredPermission(["brevo-newsletter"])
+        async isBrevoConfigDefined(
+            @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope))
+            scope: typeof Scope,
+        ): Promise<boolean> {
+            const brevoConfig = await this.repository.findOne({ scope });
+            return !!brevoConfig;
+        }
+
         @Query(() => BrevoConfig, { nullable: true })
         async brevoConfig(
             @Args("scope", { type: () => Scope }, new DynamicDtoValidationPipe(Scope))


### PR DESCRIPTION
## Description

Previously, the Send Manager threw an error when a user without the appropriate permissions attempted to access the Brevo configuration. In some projects, only certain users should have access to edit the configuration page, while a broader group should be permitted to send email campaigns.
This PR introduces a new query that allows any user with standard Brevo permissions to verify whether the configuration is set, without the config permission.

## Screenshots/screencasts
<img width="1723" alt="Screenshot 2025-06-16 at 17 55 54" src="https://github.com/user-attachments/assets/73f45f16-6c2b-4eeb-8706-8b7c7ece205a" />

The screenshot shows the error message displayed when the Brevo configuration is missing. On the left, it's clear that the user does not have access to the configuration page; however, the request to verify whether the Brevo configuration is set still succeeds.

## Task
https://vivid-planet.atlassian.net/browse/COM-2040