### PR TITLE
Switch to site nextjs

### DIFF
--- a/demo/admin/package.json
+++ b/demo/admin/package.json
@@ -56,7 +56,7 @@
         "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "^17.0.0",
         "react-final-form": "^6.3.1",
-        "react-intl": "^5.25.1",
+        "react-intl": "^7.1.11",
         "react-router": "^5.3.4",
         "react-router-dom": "^5.3.4"
     },

--- a/demo/admin/package.json
+++ b/demo/admin/package.json
@@ -94,7 +94,7 @@
         "rimraf": "^3.0.2",
         "style-loader": "^3.3.4",
         "ts-node": "^10.9.2",
-        "typescript": "^4.9.5",
+        "typescript": "^5.8.3",
         "webpack": "^5.0.0",
         "webpack-cli": "^4.10.0",
         "webpack-dev-server": "^4.15.2"

--- a/demo/api/package.json
+++ b/demo/api/package.json
@@ -115,7 +115,7 @@
         "jest": "^27.5.1",
         "jest-junit": "^13.2.0",
         "prettier": "^2.1.2",
-        "ts-jest": "^27.1.5",
+        "ts-jest": "^29.4.0",
         "ts-loader": "^8.4.0",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^3.15.0",

--- a/demo/api/package.json
+++ b/demo/api/package.json
@@ -119,7 +119,7 @@
         "ts-loader": "^8.4.0",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^3.15.0",
-        "typescript": "^4.9.5"
+        "typescript": "^5.8.3"
     },
     "mikro-orm": {
         "useTsNode": true,

--- a/demo/campaign/next.config.js
+++ b/demo/campaign/next.config.js
@@ -55,7 +55,7 @@ const nextConfig = {
         styledComponents: true,
     },
     experimental: {
-        optimizePackageImports: ["@comet/cms-site"],
+        optimizePackageImports: ["@comet/site-nextjs"],
     },
     env: {
         DAM_ALLOWED_IMAGE_SIZES: cometConfig.dam.allowedImageSizes.join(","),

--- a/demo/campaign/package.json
+++ b/demo/campaign/package.json
@@ -39,7 +39,7 @@
         "next": "^14.2.24",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
-        "react-intl": "^5.25.1",
+        "react-intl": "^7.1.11",
         "react-is": "^17.0.2",
         "redraft": "^0.10.2",
         "sitemap": "^6.4.0",

--- a/demo/campaign/package.json
+++ b/demo/campaign/package.json
@@ -72,7 +72,7 @@
         "prettier": "^2.0.0",
         "rimraf": "^3.0.2",
         "tsconfig-paths": "^3.15.0",
-        "typescript": "^4.9.5"
+        "typescript": "^5.8.3"
     },
     "peerDependencies": {
         "mjml": "^4.15.3"

--- a/demo/campaign/package.json
+++ b/demo/campaign/package.json
@@ -20,7 +20,7 @@
     },
     "dependencies": {
         "@comet/brevo-mail-rendering": "workspace:*",
-        "@comet/cms-site": "^7.21.1",
+        "@comet/site-nextjs": "7",
         "@faire/mjml-react": "^3.4.0",
         "@luma-team/mjml-react": "^0.2.1",
         "@next/bundle-analyzer": "^12.3.4",

--- a/demo/campaign/src/blocks/ContentBlock.tsx
+++ b/demo/campaign/src/blocks/ContentBlock.tsx
@@ -1,5 +1,5 @@
 import { NewsletterImageBlock } from "@comet/brevo-mail-rendering";
-import { BlocksBlock, SupportedBlocks } from "@comet/cms-site";
+import { BlocksBlock, SupportedBlocks } from "@comet/site-nextjs";
 import { EmailCampaignContentBlockData } from "@src/blocks.generated";
 import { RichTextBlock } from "@src/blocks//RichTextBlock";
 import { DividerBlock } from "@src/blocks/DividerBlock";

--- a/demo/campaign/src/blocks/ImageBlock.tsx
+++ b/demo/campaign/src/blocks/ImageBlock.tsx
@@ -1,4 +1,4 @@
-import { PropsWithData } from "@comet/cms-site";
+import { PropsWithData } from "@comet/site-nextjs";
 import { MjmlColumn, MjmlSection } from "@luma-team/mjml-react";
 import { PixelImageBlockData } from "@src/blocks.generated";
 import { CommonImageBlock } from "@src/common/blocks/CommonImageBlock";

--- a/demo/campaign/src/blocks/RichTextBlock.tsx
+++ b/demo/campaign/src/blocks/RichTextBlock.tsx
@@ -1,4 +1,4 @@
-import { PropsWithData } from "@comet/cms-site";
+import { PropsWithData } from "@comet/site-nextjs";
 import { MjmlColumn } from "@luma-team/mjml-react";
 import { RichTextBlockData } from "@src/blocks.generated";
 import { IndentedSectionGroup } from "@src/components/IndentedSectionGroup";

--- a/demo/campaign/src/blocks/SalutationBlock.tsx
+++ b/demo/campaign/src/blocks/SalutationBlock.tsx
@@ -1,4 +1,4 @@
-import { PropsWithData } from "@comet/cms-site";
+import { PropsWithData } from "@comet/site-nextjs";
 import { MjmlColumn, MjmlText } from "@luma-team/mjml-react";
 import { RichTextBlockData } from "@src/blocks.generated";
 import { IndentedSectionGroup } from "@src/components/IndentedSectionGroup";

--- a/demo/campaign/src/common/blocks/CommonImageBlock.tsx
+++ b/demo/campaign/src/common/blocks/CommonImageBlock.tsx
@@ -1,4 +1,4 @@
-import { calculateInheritAspectRatio, generateImageUrl } from "@comet/cms-site";
+import { calculateInheritAspectRatio, generateImageUrl } from "@comet/site-nextjs";
 import { MjmlImage, MjmlStyle } from "@luma-team/mjml-react";
 import { PixelImageBlockData } from "@src/blocks.generated";
 import { css } from "@src/util/stylesHelper";

--- a/demo/campaign/src/common/blocks/DamImageBlock.tsx
+++ b/demo/campaign/src/common/blocks/DamImageBlock.tsx
@@ -1,4 +1,4 @@
-import { PixelImageBlock, PreviewSkeleton, PropsWithData, SvgImageBlock, withPreview } from "@comet/cms-site";
+import { PixelImageBlock, PreviewSkeleton, PropsWithData, SvgImageBlock, withPreview } from "@comet/site-nextjs";
 import { DamImageBlockData, PixelImageBlockData, SvgImageBlockData } from "@src/blocks.generated";
 import { ImageProps } from "next/image";
 import * as React from "react";

--- a/demo/campaign/src/common/blocks/DamVideoBlock.tsx
+++ b/demo/campaign/src/common/blocks/DamVideoBlock.tsx
@@ -1,4 +1,4 @@
-import { PreviewSkeleton, PropsWithData, withPreview } from "@comet/cms-site";
+import { PreviewSkeleton, PropsWithData, withPreview } from "@comet/site-nextjs";
 import { DamVideoBlockData } from "@src/blocks.generated";
 import * as React from "react";
 

--- a/demo/campaign/src/common/blocks/HeadlineBlock.tsx
+++ b/demo/campaign/src/common/blocks/HeadlineBlock.tsx
@@ -1,4 +1,4 @@
-import { PropsWithData, withPreview } from "@comet/cms-site";
+import { PropsWithData, withPreview } from "@comet/site-nextjs";
 import { HeadlineBlockData } from "@src/blocks.generated";
 import * as React from "react";
 import { Renderers } from "redraft";

--- a/demo/campaign/src/common/blocks/LinkBlock.tsx
+++ b/demo/campaign/src/common/blocks/LinkBlock.tsx
@@ -1,4 +1,4 @@
-import { ExternalLinkBlock, InternalLinkBlock, PropsWithData, withPreview } from "@comet/cms-site";
+import { ExternalLinkBlock, InternalLinkBlock, PropsWithData, withPreview } from "@comet/site-nextjs";
 import { ExternalLinkBlockData, InternalLinkBlockData, LinkBlockData } from "@src/blocks.generated";
 import * as React from "react";
 

--- a/demo/campaign/src/common/blocks/LinkListBlock.tsx
+++ b/demo/campaign/src/common/blocks/LinkListBlock.tsx
@@ -1,4 +1,4 @@
-import { PropsWithData, withPreview } from "@comet/cms-site";
+import { PropsWithData, withPreview } from "@comet/site-nextjs";
 import { LinkListBlockData } from "@src/blocks.generated";
 import * as React from "react";
 

--- a/demo/campaign/src/common/blocks/RichTextBlock.tsx
+++ b/demo/campaign/src/common/blocks/RichTextBlock.tsx
@@ -1,4 +1,4 @@
-import { PreviewSkeleton, PropsWithData, withPreview } from "@comet/cms-site";
+import { PreviewSkeleton, PropsWithData, withPreview } from "@comet/site-nextjs";
 import { LinkBlockData, RichTextBlockData } from "@src/blocks.generated";
 import { RawDraftContentState } from "draft-js";
 import * as React from "react";

--- a/demo/campaign/src/common/blocks/SpaceBlock.tsx
+++ b/demo/campaign/src/common/blocks/SpaceBlock.tsx
@@ -1,4 +1,4 @@
-import { PropsWithData, withPreview } from "@comet/cms-site";
+import { PropsWithData, withPreview } from "@comet/site-nextjs";
 import { SpaceBlockData } from "@src/blocks.generated";
 import * as React from "react";
 

--- a/demo/campaign/src/common/blocks/TextImageBlock.tsx
+++ b/demo/campaign/src/common/blocks/TextImageBlock.tsx
@@ -1,4 +1,4 @@
-import { PropsWithData, withPreview } from "@comet/cms-site";
+import { PropsWithData, withPreview } from "@comet/site-nextjs";
 import { TextImageBlockData } from "@src/blocks.generated";
 import * as React from "react";
 import styled from "styled-components";

--- a/demo/campaign/src/common/blocks/TextLinkBlock.tsx
+++ b/demo/campaign/src/common/blocks/TextLinkBlock.tsx
@@ -1,4 +1,4 @@
-import { PropsWithData, withPreview } from "@comet/cms-site";
+import { PropsWithData, withPreview } from "@comet/site-nextjs";
 import { TextLinkBlockData } from "@src/blocks.generated";
 
 import { LinkBlock } from "./LinkBlock";

--- a/demo/campaign/src/components/RichText.tsx
+++ b/demo/campaign/src/components/RichText.tsx
@@ -1,4 +1,4 @@
-import { PropsWithData } from "@comet/cms-site";
+import { PropsWithData } from "@comet/site-nextjs";
 import { RichTextBlockData } from "@src/blocks.generated";
 import { RawDraftContentState } from "draft-js";
 import * as React from "react";

--- a/demo/campaign/src/layout/Layout.tsx
+++ b/demo/campaign/src/layout/Layout.tsx
@@ -1,3 +1,5 @@
+import "@comet/site-nextjs/css";
+
 import { gql, GraphQLClient } from "graphql-request";
 import * as React from "react";
 

--- a/demo/campaign/src/pages/block-preview/[domain]/[language]/index.page.tsx
+++ b/demo/campaign/src/pages/block-preview/[domain]/[language]/index.page.tsx
@@ -1,4 +1,4 @@
-import { BlockPreviewProvider, IFrameBridgeProvider, useIFrameBridge } from "@comet/cms-site";
+import { BlockPreviewProvider, IFrameBridgeProvider, useIFrameBridge } from "@comet/site-nextjs";
 import { generateMjmlMailContent, IntlProviderValues, RenderedMail } from "@src/components/RenderedMail";
 import { defaultLanguage } from "@src/config";
 import { getMessages } from "@src/lang";

--- a/demo/site/next.config.js
+++ b/demo/site/next.config.js
@@ -64,7 +64,7 @@ const nextConfig = {
         styledComponents: true,
     },
     experimental: {
-        optimizePackageImports: ["@comet/cms-site"],
+        optimizePackageImports: ["@comet/site-nextjs"],
     },
     // https://nextjs.org/docs/advanced-features/security-headers
     headers: async () => [

--- a/demo/site/package.json
+++ b/demo/site/package.json
@@ -25,7 +25,7 @@
         "serve": "npm run extract:publicGenerated && NODE_ENV=production node server.js"
     },
     "dependencies": {
-        "@comet/cms-site": "^7.21.1",
+        "@comet/site-nextjs": "7",
         "@next/bundle-analyzer": "^12.3.4",
         "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/auto-instrumentations-node": "^0.40.0",

--- a/demo/site/package.json
+++ b/demo/site/package.json
@@ -40,7 +40,7 @@
         "next": "^14.2.24",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
-        "react-intl": "^5.25.1",
+        "react-intl": "^7.1.11",
         "react-is": "^17.0.2",
         "redraft": "^0.10.2",
         "sitemap": "^6.4.0",

--- a/demo/site/package.json
+++ b/demo/site/package.json
@@ -72,6 +72,6 @@
         "prettier": "^2.0.0",
         "rimraf": "^3.0.2",
         "tsconfig-paths": "^3.15.0",
-        "typescript": "^4.9.5"
+        "typescript": "^5.8.3"
     }
 }

--- a/demo/site/src/common/blocks/DamImageBlock.tsx
+++ b/demo/site/src/common/blocks/DamImageBlock.tsx
@@ -1,4 +1,4 @@
-import { PixelImageBlock, PreviewSkeleton, PropsWithData, SvgImageBlock, withPreview } from "@comet/cms-site";
+import { PixelImageBlock, PreviewSkeleton, PropsWithData, SvgImageBlock, withPreview } from "@comet/site-nextjs";
 import { DamImageBlockData, PixelImageBlockData, SvgImageBlockData } from "@src/blocks.generated";
 import { ImageProps } from "next/image";
 import * as React from "react";

--- a/demo/site/src/common/blocks/DamVideoBlock.tsx
+++ b/demo/site/src/common/blocks/DamVideoBlock.tsx
@@ -1,4 +1,4 @@
-import { PreviewSkeleton, PropsWithData, withPreview } from "@comet/cms-site";
+import { PreviewSkeleton, PropsWithData, withPreview } from "@comet/site-nextjs";
 import { DamVideoBlockData } from "@src/blocks.generated";
 import * as React from "react";
 

--- a/demo/site/src/common/blocks/HeadlineBlock.tsx
+++ b/demo/site/src/common/blocks/HeadlineBlock.tsx
@@ -1,4 +1,4 @@
-import { PropsWithData, withPreview } from "@comet/cms-site";
+import { PropsWithData, withPreview } from "@comet/site-nextjs";
 import { HeadlineBlockData } from "@src/blocks.generated";
 import * as React from "react";
 import { Renderers } from "redraft";

--- a/demo/site/src/common/blocks/LinkBlock.tsx
+++ b/demo/site/src/common/blocks/LinkBlock.tsx
@@ -1,4 +1,4 @@
-import { ExternalLinkBlock, InternalLinkBlock, PropsWithData, withPreview } from "@comet/cms-site";
+import { ExternalLinkBlock, InternalLinkBlock, PropsWithData, withPreview } from "@comet/site-nextjs";
 import { ExternalLinkBlockData, InternalLinkBlockData, LinkBlockData } from "@src/blocks.generated";
 import * as React from "react";
 

--- a/demo/site/src/common/blocks/LinkListBlock.tsx
+++ b/demo/site/src/common/blocks/LinkListBlock.tsx
@@ -1,4 +1,4 @@
-import { PropsWithData, withPreview } from "@comet/cms-site";
+import { PropsWithData, withPreview } from "@comet/site-nextjs";
 import { LinkListBlockData } from "@src/blocks.generated";
 import * as React from "react";
 

--- a/demo/site/src/common/blocks/RichTextBlock.tsx
+++ b/demo/site/src/common/blocks/RichTextBlock.tsx
@@ -1,4 +1,4 @@
-import { PreviewSkeleton, PropsWithData, withPreview } from "@comet/cms-site";
+import { PreviewSkeleton, PropsWithData, withPreview } from "@comet/site-nextjs";
 import { LinkBlockData, RichTextBlockData } from "@src/blocks.generated";
 import { RawDraftContentState } from "draft-js";
 import * as React from "react";

--- a/demo/site/src/common/blocks/SpaceBlock.tsx
+++ b/demo/site/src/common/blocks/SpaceBlock.tsx
@@ -1,4 +1,4 @@
-import { PropsWithData, withPreview } from "@comet/cms-site";
+import { PropsWithData, withPreview } from "@comet/site-nextjs";
 import { SpaceBlockData } from "@src/blocks.generated";
 import * as React from "react";
 

--- a/demo/site/src/common/blocks/TextImageBlock.tsx
+++ b/demo/site/src/common/blocks/TextImageBlock.tsx
@@ -1,4 +1,4 @@
-import { PropsWithData, withPreview } from "@comet/cms-site";
+import { PropsWithData, withPreview } from "@comet/site-nextjs";
 import { TextImageBlockData } from "@src/blocks.generated";
 import * as React from "react";
 import styled from "styled-components";

--- a/demo/site/src/common/blocks/TextLinkBlock.tsx
+++ b/demo/site/src/common/blocks/TextLinkBlock.tsx
@@ -1,4 +1,4 @@
-import { PropsWithData, withPreview } from "@comet/cms-site";
+import { PropsWithData, withPreview } from "@comet/site-nextjs";
 import { TextLinkBlockData } from "@src/blocks.generated";
 
 import { LinkBlock } from "./LinkBlock";

--- a/demo/site/src/documents/pages/blocks/PageContentBlock.tsx
+++ b/demo/site/src/documents/pages/blocks/PageContentBlock.tsx
@@ -1,4 +1,4 @@
-import { BlocksBlock, DamVideoBlock, PropsWithData, SupportedBlocks, YouTubeVideoBlock } from "@comet/cms-site";
+import { BlocksBlock, DamVideoBlock, PropsWithData, SupportedBlocks, YouTubeVideoBlock } from "@comet/site-nextjs";
 import { PageContentBlockData } from "@src/blocks.generated";
 import { DamImageBlock } from "@src/common/blocks/DamImageBlock";
 import { HeadlineBlock } from "@src/common/blocks/HeadlineBlock";

--- a/demo/site/src/documents/pages/blocks/SeoBlock.tsx
+++ b/demo/site/src/documents/pages/blocks/SeoBlock.tsx
@@ -1,4 +1,4 @@
-import { generateImageUrl, PropsWithData } from "@comet/cms-site";
+import { generateImageUrl, PropsWithData } from "@comet/site-nextjs";
 import { SeoBlockData } from "@src/blocks.generated";
 import Head from "next/head";
 import * as React from "react";

--- a/demo/site/src/layout/Layout.tsx
+++ b/demo/site/src/layout/Layout.tsx
@@ -1,3 +1,5 @@
+import "@comet/site-nextjs/css";
+
 import { gql, GraphQLClient } from "graphql-request";
 import * as React from "react";
 

--- a/demo/site/src/pages/[[...path]].page.tsx
+++ b/demo/site/src/pages/[[...path]].page.tsx
@@ -1,4 +1,4 @@
-import { SitePreviewParams } from "@comet/cms-site";
+import { SitePreviewParams } from "@comet/site-nextjs";
 import { ContentScope } from "@src/common/contentScope/ContentScope";
 import { defaultLanguage, domain as configuredDomain, domain } from "@src/config";
 import { Page as PageTypePage, pageQuery as PageTypePageQuery } from "@src/documents/pages/Page";

--- a/demo/site/src/pages/_app.page.tsx
+++ b/demo/site/src/pages/_app.page.tsx
@@ -1,4 +1,4 @@
-import { SitePreviewProvider } from "@comet/cms-site";
+import { SitePreviewProvider } from "@comet/site-nextjs";
 import { ContentScope, ContentScopeProvider } from "@src/common/contentScope/ContentScope";
 import { defaultLanguage, domain } from "@src/config";
 import App, { AppProps, NextWebVitalsMetric } from "next/app";

--- a/demo/site/src/pages/api/site-preview.page.ts
+++ b/demo/site/src/pages/api/site-preview.page.ts
@@ -1,4 +1,4 @@
-import { legacyPagesRouterSitePreviewApiHandler } from "@comet/cms-site";
+import { legacyPagesRouterSitePreviewApiHandler } from "@comet/site-nextjs";
 import { createGraphQLClient } from "@src/util/createGraphQLClient";
 import { NextApiHandler } from "next";
 

--- a/demo/site/src/pages/block-preview/page/content.page.tsx
+++ b/demo/site/src/pages/block-preview/page/content.page.tsx
@@ -1,4 +1,4 @@
-import { BlockPreviewProvider, IFrameBridgeProvider, useIFrameBridge } from "@comet/cms-site";
+import { BlockPreviewProvider, IFrameBridgeProvider, useIFrameBridge } from "@comet/site-nextjs";
 import { PageContentBlock } from "@src/documents/pages/blocks/PageContentBlock";
 import * as React from "react";
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,11 @@
                     "@types/react": "^18.0.0"
                 }
             },
+            "@comet/site-react@7": {
+                "peerDependencies": {
+                    "@types/react": "^18.0.0"
+                }
+            },
             "@faire/mjml-react@3": {
                 "peerDependencies": {
                     "@types/react": "^18.0.0"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "open-cli": "^7.2.0",
         "prettier": "^2.3.2",
         "ts-node": "^10.9.2",
-        "typescript": "^4.9.5"
+        "typescript": "^5.8.3"
     },
     "pnpm": {
         "packageExtensions": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
                     "@types/react": "^18.0.0"
                 }
             },
-            "@comet/cms-site@7": {
+            "@comet/site-nextjs@7": {
                 "peerDependencies": {
                     "@types/react": "^18.0.0"
                 }

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -67,7 +67,7 @@
         "react-dnd-html5-backend": "^16.0.1",
         "react-dom": "^17.0",
         "react-final-form": "^6.3.1",
-        "react-intl": "^5.25.1",
+        "react-intl": "^7.1.11",
         "react-router": "^5.3.4",
         "react-router-dom": "^5.3.4",
         "rimraf": "^3.0.2",

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -71,7 +71,7 @@
         "react-router": "^5.3.4",
         "react-router-dom": "^5.3.4",
         "rimraf": "^3.0.2",
-        "typescript": "^4.9.5"
+        "typescript": "^5.8.3"
     },
     "peerDependencies": {
         "@apollo/client": "^3.12.2",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -74,7 +74,7 @@
         "rxjs": "^7.0.0",
         "ts-jest": "^29.0.5",
         "ts-node": "^10.9.2",
-        "typescript": "^4.9.5",
+        "typescript": "^5.8.3",
         "uuid": "^8.3.2"
     },
     "peerDependencies": {

--- a/packages/mail-rendering/package.json
+++ b/packages/mail-rendering/package.json
@@ -25,8 +25,8 @@
     },
     "devDependencies": {
         "@comet/cli": "^7.21.1",
-        "@comet/cms-site": "^7.21.1",
         "@comet/eslint-config": "^7.21.1",
+        "@comet/site-nextjs": "7",
         "@luma-team/mjml-react": "^0.2.1",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
@@ -42,7 +42,7 @@
         "typescript": "^5.8.3"
     },
     "peerDependencies": {
-        "@comet/cms-site": "^7.0.0",
+        "@comet/site-nextjs": "7",
         "@luma-team/mjml-react": "^0.2.1",
         "mjml": "^4.15.3",
         "next": "^14.2.25",

--- a/packages/mail-rendering/package.json
+++ b/packages/mail-rendering/package.json
@@ -39,7 +39,7 @@
         "react-dom": "^18.3.1",
         "rimraf": "^6.0.1",
         "styled-components": "^6.1.18",
-        "typescript": "^4.9.5"
+        "typescript": "^5.8.3"
     },
     "peerDependencies": {
         "@comet/cms-site": "^7.0.0",

--- a/packages/mail-rendering/src/blocks/NewsletterImageBlock.tsx
+++ b/packages/mail-rendering/src/blocks/NewsletterImageBlock.tsx
@@ -1,4 +1,4 @@
-import { PropsWithData } from "@comet/cms-site";
+import { PropsWithData } from "@comet/site-nextjs";
 import { MjmlColumn, MjmlSection } from "@luma-team/mjml-react";
 
 import { NewsletterImageBlockData } from "../blocks.generated";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-packageExtensionsChecksum: 1765bd3cc36f4272c47f92ca9277c87a
+packageExtensionsChecksum: d49dd8bfa1afbaf0bd915a809f50d42b
 
 importers:
 
@@ -486,9 +486,9 @@ importers:
       '@comet/brevo-mail-rendering':
         specifier: workspace:*
         version: link:../../packages/mail-rendering
-      '@comet/cms-site':
-        specifier: ^7.21.1
-        version: 7.25.1(@types/react@18.3.12)(next@14.2.25)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.19)
+      '@comet/site-nextjs':
+        specifier: '7'
+        version: 7.25.6(@types/react@18.3.12)(next@14.2.25)(react-dom@18.3.1)(react@18.3.1)
       '@faire/mjml-react':
         specifier: ^3.4.0
         version: 3.4.0(@types/react@18.3.12)(mjml@4.15.3)(react-dom@18.3.1)(react@18.3.1)
@@ -643,9 +643,9 @@ importers:
 
   demo/site:
     dependencies:
-      '@comet/cms-site':
-        specifier: ^7.21.1
-        version: 7.25.1(@types/react@18.3.12)(next@14.2.25)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.19)
+      '@comet/site-nextjs':
+        specifier: '7'
+        version: 7.25.6(@types/react@18.3.12)(next@14.2.25)(react-dom@18.3.1)(react@18.3.1)
       '@next/bundle-analyzer':
         specifier: ^12.3.4
         version: 12.3.4
@@ -1060,12 +1060,12 @@ importers:
       '@comet/cli':
         specifier: ^7.21.1
         version: 7.25.1(ts-node@10.9.2)
-      '@comet/cms-site':
-        specifier: ^7.21.1
-        version: 7.25.1(@types/react@18.3.12)(next@14.2.25)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.19)
       '@comet/eslint-config':
         specifier: ^7.21.1
         version: 7.25.1(eslint@8.56.0)(next@14.2.25)(prettier@2.8.8)(typescript@5.9.2)
+      '@comet/site-nextjs':
+        specifier: '7'
+        version: 7.25.6(@types/react@18.3.12)(next@14.2.25)(react-dom@18.3.1)(react@18.3.1)
       '@luma-team/mjml-react':
         specifier: ^0.2.1
         version: 0.2.1(react-dom@18.3.1)(react@18.3.1)
@@ -4279,27 +4279,6 @@ packages:
       - ws
       - zod
 
-  /@comet/cms-site@7.25.1(@types/react@18.3.12)(next@14.2.25)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.19):
-    resolution: {integrity: sha512-TX4ioSzeK0kySMAzPh795+4OmF5ktCwEpvDSbMQfhKR7NAb1mVrDN3fmDs5sblfMvDQpqunX9EPY9eL2RhjA9g==}
-    peerDependencies:
-      '@types/react': ^18.0.0
-      next: ^14.2.0
-      react: ^18.0.0
-      react-dom: ^18.0.0
-      styled-components: ^5.0.0 || ^6.0.0
-    dependencies:
-      '@types/react': 18.3.12
-      jose: 5.9.6
-      lodash.isequal: 4.5.0
-      next: 14.2.25(@babel/core@7.26.0)(@opentelemetry/api@1.7.0)(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      rimraf: 3.0.2
-      scroll-into-view-if-needed: 2.2.31
-      server-only: 0.0.1
-      styled-components: 6.1.19(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1)
-      usehooks-ts: 3.1.0(react@18.3.1)
-
   /@comet/dev-process-manager@2.7.0:
     resolution: {integrity: sha512-BtCOF687GO1ccwm7ecHfIV57glnLSG+OsReEolomZJe3OeToMWjUpMyfJ+/5zm2m5EpzePA+kABhbIZk/Va90g==}
     engines: {node: '>=14'}
@@ -4438,6 +4417,45 @@ packages:
     dependencies:
       eslint: 8.56.0
     dev: true
+
+  /@comet/site-nextjs@7.25.6(@types/react@18.3.12)(next@14.2.25)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-4+Ftl+spgo1N10Hjk+IRcHMtGAwOfVxpMz2pUtAWeOVsZ/LxSAjxgyPOCKLpY3kEwIdjYGx3svR7xTurw1hjXA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@types/react': ^18.0.0
+      next: ^14.2.0
+      react: ^18.0.0
+      react-dom: ^18.0.0
+    dependencies:
+      '@comet/site-react': 7.25.6(react-dom@18.3.1)(react@18.3.1)
+      '@types/react': 18.3.12
+      clsx: 2.1.1
+      jose: 5.9.6
+      lodash.isequal: 4.5.0
+      next: 14.2.25(@babel/core@7.26.0)(@opentelemetry/api@1.7.0)(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      rimraf: 3.0.2
+      scroll-into-view-if-needed: 2.2.31
+      server-only: 0.0.1
+      usehooks-ts: 3.1.0(react@18.3.1)
+
+  /@comet/site-react@7.25.6(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-YUYOVIlUEuT/FVsx1wCBv5elNmlmwq921TkackUIguIK5kZNM8iYzGa+rghB8VwBTeOLAfJi14UTKde3xFzycg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
+    dependencies:
+      clsx: 2.1.1
+      jose: 5.9.6
+      lodash.isequal: 4.5.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      rimraf: 3.0.2
+      scroll-into-view-if-needed: 2.2.31
+      server-only: 0.0.1
+      usehooks-ts: 3.1.0(react@18.3.1)
 
   /@cspotcode/source-map-support@0.8.1:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-packageExtensionsChecksum: d49dd8bfa1afbaf0bd915a809f50d42b
+packageExtensionsChecksum: cd8d6b2790db40677bdcaf71c6d0471a
 
 importers:
 
@@ -4427,7 +4427,7 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
     dependencies:
-      '@comet/site-react': 7.25.6(react-dom@18.3.1)(react@18.3.1)
+      '@comet/site-react': 7.25.6(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1)
       '@types/react': 18.3.12
       clsx: 2.1.1
       jose: 5.9.6
@@ -4440,13 +4440,15 @@ packages:
       server-only: 0.0.1
       usehooks-ts: 3.1.0(react@18.3.1)
 
-  /@comet/site-react@7.25.6(react-dom@18.3.1)(react@18.3.1):
+  /@comet/site-react@7.25.6(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1):
     resolution: {integrity: sha512-YUYOVIlUEuT/FVsx1wCBv5elNmlmwq921TkackUIguIK5kZNM8iYzGa+rghB8VwBTeOLAfJi14UTKde3xFzycg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
+      '@types/react': ^18.0.0
       react: ^18.0.0
       react-dom: ^18.0.0
     dependencies:
+      '@types/react': 18.3.12
       clsx: 2.1.1
       jose: 5.9.6
       lodash.isequal: 4.5.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,7 +416,7 @@ importers:
     devDependencies:
       '@comet/eslint-config':
         specifier: ^7.21.1
-        version: 7.25.1(eslint@8.56.0)(prettier@2.8.8)(ts-jest@27.1.5)(typescript@5.9.2)
+        version: 7.25.1(eslint@8.56.0)(prettier@2.8.8)(ts-jest@29.4.1)(typescript@5.9.2)
       '@nestjs/cli':
         specifier: ^9.5.0
         version: 9.5.0
@@ -466,8 +466,8 @@ importers:
         specifier: ^2.1.2
         version: 2.8.8
       ts-jest:
-        specifier: ^27.1.5
-        version: 27.1.5(@types/jest@27.5.2)(jest@27.5.1)(typescript@5.9.2)
+        specifier: ^29.4.0
+        version: 29.4.1(jest@27.5.1)(typescript@5.9.2)
       ts-loader:
         specifier: ^8.4.0
         version: 8.4.0(typescript@5.9.2)(webpack@5.94.0)
@@ -4357,43 +4357,6 @@ packages:
       - typescript
     dev: true
 
-  /@comet/eslint-config@7.25.1(eslint@8.56.0)(prettier@2.8.8)(ts-jest@27.1.5)(typescript@5.9.2):
-    resolution: {integrity: sha512-0e+yc9L3VAb0ZcnHEMiwT31Xzm/qhs/GPwS7oretxvzjFy0t1vqqd8dRPMU/GpnlER3OnTut2uRIVGvbNrk8GA==}
-    peerDependencies:
-      eslint: '>= 8'
-      next: '*'
-      prettier: ^2.0.0
-    peerDependenciesMeta:
-      next:
-        optional: true
-    dependencies:
-      '@calm/eslint-plugin-react-intl': 1.4.1
-      '@comet/eslint-plugin': 7.25.1(eslint@8.56.0)
-      '@next/eslint-plugin-next': 14.2.16
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.56.0)(typescript@5.9.2)
-      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.9.2)
-      eslint: 8.56.0
-      eslint-config-next: 14.2.16(eslint@8.56.0)(typescript@5.9.2)
-      eslint-config-prettier: 8.10.0(eslint@8.56.0)
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
-      eslint-plugin-formatjs: 4.12.1(eslint@8.56.0)(ts-jest@27.1.5)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
-      eslint-plugin-json-files: 2.2.0(eslint@8.56.0)
-      eslint-plugin-prettier: 4.2.1(eslint-config-prettier@8.10.0)(eslint@8.56.0)(prettier@2.8.8)
-      eslint-plugin-react: 7.33.2(eslint@8.56.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
-      eslint-plugin-simple-import-sort: 9.0.0(eslint@8.56.0)
-      eslint-plugin-unused-imports: 2.0.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.56.0)
-      npm-run-all: 4.1.5
-      prettier: 2.8.8
-    transitivePeerDependencies:
-      - eslint-import-resolver-node
-      - eslint-import-resolver-webpack
-      - supports-color
-      - ts-jest
-      - typescript
-    dev: true
-
   /@comet/eslint-config@7.25.1(eslint@8.56.0)(prettier@2.8.8)(ts-jest@29.1.1)(typescript@5.9.2):
     resolution: {integrity: sha512-0e+yc9L3VAb0ZcnHEMiwT31Xzm/qhs/GPwS7oretxvzjFy0t1vqqd8dRPMU/GpnlER3OnTut2uRIVGvbNrk8GA==}
     peerDependencies:
@@ -4414,6 +4377,43 @@ packages:
       eslint-config-prettier: 8.10.0(eslint@8.56.0)
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
       eslint-plugin-formatjs: 4.12.1(eslint@8.56.0)(ts-jest@29.1.1)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
+      eslint-plugin-json-files: 2.2.0(eslint@8.56.0)
+      eslint-plugin-prettier: 4.2.1(eslint-config-prettier@8.10.0)(eslint@8.56.0)(prettier@2.8.8)
+      eslint-plugin-react: 7.33.2(eslint@8.56.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
+      eslint-plugin-simple-import-sort: 9.0.0(eslint@8.56.0)
+      eslint-plugin-unused-imports: 2.0.0(@typescript-eslint/eslint-plugin@5.62.0)(eslint@8.56.0)
+      npm-run-all: 4.1.5
+      prettier: 2.8.8
+    transitivePeerDependencies:
+      - eslint-import-resolver-node
+      - eslint-import-resolver-webpack
+      - supports-color
+      - ts-jest
+      - typescript
+    dev: true
+
+  /@comet/eslint-config@7.25.1(eslint@8.56.0)(prettier@2.8.8)(ts-jest@29.4.1)(typescript@5.9.2):
+    resolution: {integrity: sha512-0e+yc9L3VAb0ZcnHEMiwT31Xzm/qhs/GPwS7oretxvzjFy0t1vqqd8dRPMU/GpnlER3OnTut2uRIVGvbNrk8GA==}
+    peerDependencies:
+      eslint: '>= 8'
+      next: '*'
+      prettier: ^2.0.0
+    peerDependenciesMeta:
+      next:
+        optional: true
+    dependencies:
+      '@calm/eslint-plugin-react-intl': 1.4.1
+      '@comet/eslint-plugin': 7.25.1(eslint@8.56.0)
+      '@next/eslint-plugin-next': 14.2.16
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.56.0)(typescript@5.9.2)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.9.2)
+      eslint: 8.56.0
+      eslint-config-next: 14.2.16(eslint@8.56.0)(typescript@5.9.2)
+      eslint-config-prettier: 8.10.0(eslint@8.56.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
+      eslint-plugin-formatjs: 4.12.1(eslint@8.56.0)(ts-jest@29.4.1)
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.6.1)(eslint@8.56.0)
       eslint-plugin-json-files: 2.2.0(eslint@8.56.0)
       eslint-plugin-prettier: 4.2.1(eslint-config-prettier@8.10.0)(eslint@8.56.0)(prettier@2.8.8)
@@ -4848,24 +4848,6 @@ packages:
       tslib: 2.8.1
       typescript: 5.9.2
 
-  /@formatjs/ts-transformer@3.13.11(ts-jest@27.1.5):
-    resolution: {integrity: sha512-qOAGGUQC7GSMMaAFy2MAlC8REM58lUNi8W+VlRb57cDUpge46x2hP33Mzu5N1xmm6OCqDQTRXws5jEOcRI3C8Q==}
-    peerDependencies:
-      ts-jest: '>=27'
-    peerDependenciesMeta:
-      ts-jest:
-        optional: true
-    dependencies:
-      '@formatjs/icu-messageformat-parser': 2.7.5
-      '@types/json-stable-stringify': 1.0.36
-      '@types/node': 17.0.45
-      chalk: 4.1.2
-      json-stable-stringify: 1.1.1
-      ts-jest: 27.1.5(@types/jest@27.5.2)(jest@27.5.1)(typescript@5.9.2)
-      tslib: 2.8.1
-      typescript: 5.9.2
-    dev: true
-
   /@formatjs/ts-transformer@3.13.11(ts-jest@29.1.1):
     resolution: {integrity: sha512-qOAGGUQC7GSMMaAFy2MAlC8REM58lUNi8W+VlRb57cDUpge46x2hP33Mzu5N1xmm6OCqDQTRXws5jEOcRI3C8Q==}
     peerDependencies:
@@ -4880,6 +4862,24 @@ packages:
       chalk: 4.1.2
       json-stable-stringify: 1.1.1
       ts-jest: 29.1.1(jest@29.7.0)(typescript@5.9.2)
+      tslib: 2.8.1
+      typescript: 5.9.2
+    dev: true
+
+  /@formatjs/ts-transformer@3.13.11(ts-jest@29.4.1):
+    resolution: {integrity: sha512-qOAGGUQC7GSMMaAFy2MAlC8REM58lUNi8W+VlRb57cDUpge46x2hP33Mzu5N1xmm6OCqDQTRXws5jEOcRI3C8Q==}
+    peerDependencies:
+      ts-jest: '>=27'
+    peerDependenciesMeta:
+      ts-jest:
+        optional: true
+    dependencies:
+      '@formatjs/icu-messageformat-parser': 2.7.5
+      '@types/json-stable-stringify': 1.0.36
+      '@types/node': 17.0.45
+      chalk: 4.1.2
+      json-stable-stringify: 1.1.1
+      ts-jest: 29.4.1(jest@27.5.1)(typescript@5.9.2)
       tslib: 2.8.1
       typescript: 5.9.2
     dev: true
@@ -12917,13 +12917,13 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-formatjs@4.12.1(eslint@8.56.0)(ts-jest@27.1.5):
+  /eslint-plugin-formatjs@4.12.1(eslint@8.56.0)(ts-jest@29.1.1):
     resolution: {integrity: sha512-n+lH0El6ig4Oz7ue9fd8XKUNq/fZ6L2OxP7baa8FcMYFBmlx186yULkrquVV+gLbqWDIYhQt0RmqMplTTg/msw==}
     peerDependencies:
       eslint: 7 || 8
     dependencies:
       '@formatjs/icu-messageformat-parser': 2.7.5
-      '@formatjs/ts-transformer': 3.13.11(ts-jest@27.1.5)
+      '@formatjs/ts-transformer': 3.13.11(ts-jest@29.1.1)
       '@types/eslint': 8.56.2
       '@types/picomatch': 2.3.3
       '@typescript-eslint/utils': 6.19.0(eslint@8.56.0)(typescript@5.9.2)
@@ -12939,13 +12939,13 @@ packages:
       - ts-jest
     dev: true
 
-  /eslint-plugin-formatjs@4.12.1(eslint@8.56.0)(ts-jest@29.1.1):
+  /eslint-plugin-formatjs@4.12.1(eslint@8.56.0)(ts-jest@29.4.1):
     resolution: {integrity: sha512-n+lH0El6ig4Oz7ue9fd8XKUNq/fZ6L2OxP7baa8FcMYFBmlx186yULkrquVV+gLbqWDIYhQt0RmqMplTTg/msw==}
     peerDependencies:
       eslint: 7 || 8
     dependencies:
       '@formatjs/icu-messageformat-parser': 2.7.5
-      '@formatjs/ts-transformer': 3.13.11(ts-jest@29.1.1)
+      '@formatjs/ts-transformer': 3.13.11(ts-jest@29.4.1)
       '@types/eslint': 8.56.2
       '@types/picomatch': 2.3.3
       '@typescript-eslint/utils': 6.19.0(eslint@8.56.0)(typescript@5.9.2)
@@ -14374,6 +14374,19 @@ packages:
 
   /handle-thing@2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
+
+  /handlebars@4.7.8:
+    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.17.4
+    dev: true
 
   /har-schema@2.0.0:
     resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
@@ -19914,6 +19927,12 @@ packages:
     dependencies:
       lru-cache: 6.0.0
 
+  /semver@7.7.2:
+    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dev: true
+
   /send@0.18.0:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
     engines: {node: '>= 0.8.0'}
@@ -20954,40 +20973,6 @@ packages:
     dependencies:
       tslib: 2.8.1
 
-  /ts-jest@27.1.5(@types/jest@27.5.2)(jest@27.5.1)(typescript@5.9.2):
-    resolution: {integrity: sha512-Xv6jBQPoBEvBq/5i2TeSG9tt/nqkbpcurrEG1b+2yfBrcJelOZF9Ml6dmyMh7bcW9JyFbRYpR5rxROSlBLTZHA==}
-    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    hasBin: true
-    peerDependencies:
-      '@babel/core': '>=7.0.0-beta.0 <8'
-      '@types/jest': ^27.0.0
-      babel-jest: '>=27.0.0 <28'
-      esbuild: '*'
-      jest: ^27.0.0
-      typescript: '>=3.8 <5.0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@types/jest':
-        optional: true
-      babel-jest:
-        optional: true
-      esbuild:
-        optional: true
-    dependencies:
-      '@types/jest': 27.5.2
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      jest: 27.5.1(ts-node@10.9.2)
-      jest-util: 27.5.1
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.5.4
-      typescript: 5.9.2
-      yargs-parser: 20.2.9
-    dev: true
-
   /ts-jest@29.1.1(jest@29.7.0)(typescript@5.9.2):
     resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -21017,6 +21002,46 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.5.4
+      typescript: 5.9.2
+      yargs-parser: 21.1.1
+    dev: true
+
+  /ts-jest@29.4.1(jest@27.5.1)(typescript@5.9.2):
+    resolution: {integrity: sha512-SaeUtjfpg9Uqu8IbeDKtdaS0g8lS6FT6OzM3ezrDfErPJPHNDo/Ey+VFGP1bQIDfagYDLyRpd7O15XpG1Es2Uw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/transform': ^29.0.0 || ^30.0.0
+      '@jest/types': ^29.0.0 || ^30.0.0
+      babel-jest: ^29.0.0 || ^30.0.0
+      esbuild: '*'
+      jest: ^29.0.0 || ^30.0.0
+      jest-util: ^29.0.0 || ^30.0.0
+      typescript: '>=4.3 <6'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/transform':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+      jest-util:
+        optional: true
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.8
+      jest: 27.5.1(ts-node@10.9.2)
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.2
+      type-fest: 4.41.0
       typescript: 5.9.2
       yargs-parser: 21.1.1
     dev: true
@@ -21195,6 +21220,11 @@ packages:
   /type-fest@3.13.1:
     resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
     engines: {node: '>=14.16'}
+
+  /type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+    dev: true
 
   /type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -22001,6 +22031,10 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       execa: 4.1.0
+    dev: true
+
+  /wordwrap@1.0.0:
+    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
     dev: true
 
   /wrap-ansi@5.1.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,25 +57,25 @@ importers:
         version: 7.26.0
       '@comet/admin':
         specifier: ^7.21.1
-        version: 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
+        version: 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@7.1.11)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
       '@comet/admin-icons':
         specifier: ^7.21.1
         version: 7.25.1(@mui/material@5.17.1)(react-dom@17.0.2)(react@17.0.2)
       '@comet/admin-rte':
         specifier: ^7.21.1
-        version: 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(draft-js@0.11.7)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
+        version: 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(draft-js@0.11.7)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@7.1.11)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
       '@comet/admin-theme':
         specifier: ^7.21.1
         version: 7.25.1(@mui/material@5.17.1)(@mui/system@5.17.1)(@types/react@17.0.75)(react-dom@17.0.2)(react@17.0.2)
       '@comet/blocks-admin':
         specifier: ^7.21.1
-        version: 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
+        version: 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@7.1.11)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
       '@comet/brevo-admin':
         specifier: workspace:*
         version: link:../../packages/admin
       '@comet/cms-admin':
         specifier: ^7.21.1
-        version: 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(draft-js@0.11.7)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
+        version: 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(draft-js@0.11.7)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@7.1.11)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
       '@emotion/react':
         specifier: ^11.9.3
         version: 11.11.3(@types/react@17.0.75)(react@17.0.2)
@@ -149,8 +149,8 @@ importers:
         specifier: ^6.3.1
         version: 6.5.9(final-form@4.20.10)(react@17.0.2)
       react-intl:
-        specifier: ^5.25.1
-        version: 5.25.1(@types/react@17.0.75)(react@17.0.2)(typescript@5.9.2)
+        specifier: ^7.1.11
+        version: 7.1.11(@types/react@17.0.75)(react@17.0.2)(typescript@5.9.2)
       react-router:
         specifier: ^5.3.4
         version: 5.3.4(react@17.0.2)
@@ -544,8 +544,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.1(react@18.3.1)
       react-intl:
-        specifier: ^5.25.1
-        version: 5.25.1(@types/react@18.3.12)(react@18.3.1)(typescript@5.9.2)
+        specifier: ^7.1.11
+        version: 7.1.11(@types/react@18.3.12)(react@18.3.1)(typescript@5.9.2)
       react-is:
         specifier: ^17.0.2
         version: 17.0.2
@@ -689,8 +689,8 @@ importers:
         specifier: ^18.0.0
         version: 18.3.1(react@18.3.1)
       react-intl:
-        specifier: ^5.25.1
-        version: 5.25.1(@types/react@18.3.12)(react@18.3.1)(typescript@5.9.2)
+        specifier: ^7.1.11
+        version: 7.1.11(@types/react@18.3.12)(react@18.3.1)(typescript@5.9.2)
       react-is:
         specifier: ^17.0.2
         version: 17.0.2
@@ -809,22 +809,22 @@ importers:
         version: 7.26.0
       '@comet/admin':
         specifier: ^7.21.1
-        version: 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
+        version: 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@7.1.11)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
       '@comet/admin-babel-preset':
         specifier: ^7.21.1
         version: 7.25.1(@babel/cli@7.25.9)
       '@comet/admin-date-time':
         specifier: ^7.21.1
-        version: 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
+        version: 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@7.1.11)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
       '@comet/admin-icons':
         specifier: ^7.21.1
         version: 7.25.1(@mui/material@5.17.1)(react-dom@17.0.2)(react@17.0.2)
       '@comet/blocks-admin':
         specifier: ^7.21.1
-        version: 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
+        version: 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@7.1.11)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
       '@comet/cms-admin':
         specifier: ^7.21.1
-        version: 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(draft-js@0.11.7)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
+        version: 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(draft-js@0.11.7)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@7.1.11)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
       '@comet/eslint-config':
         specifier: ^7.21.1
         version: 7.25.1(eslint@8.56.0)(next@14.2.25)(prettier@2.8.8)(typescript@5.9.2)
@@ -898,8 +898,8 @@ importers:
         specifier: ^6.3.1
         version: 6.5.9(final-form@4.20.10)(react@17.0.2)
       react-intl:
-        specifier: ^5.25.1
-        version: 5.25.1(@types/react@17.0.75)(react@17.0.2)(typescript@5.9.2)
+        specifier: ^7.1.11
+        version: 7.1.11(@types/react@17.0.75)(react@17.0.2)(typescript@5.9.2)
       react-router:
         specifier: ^5.3.4
         version: 5.3.4(react@17.0.2)
@@ -3868,7 +3868,7 @@ packages:
       - supports-color
     dev: true
 
-  /@comet/admin-date-time@7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2):
+  /@comet/admin-date-time@7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@7.1.11)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2):
     resolution: {integrity: sha512-w/uteNzzM79kNz0CmoPf6DGuP7ARoQ6GgMkXifxCCb+DsMDu6YropRl3MZ64WtMkMGu7bwk1Zj4cA1gmqQeXqw==}
     peerDependencies:
       '@mui/material': ^5.0.0
@@ -3877,7 +3877,7 @@ packages:
       react-final-form: ^6.5.7
       react-intl: ^5.0.0 || ^6.0.0
     dependencies:
-      '@comet/admin': 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
+      '@comet/admin': 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@7.1.11)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
       '@comet/admin-icons': 7.25.1(@mui/material@5.17.1)(react-dom@17.0.2)(react@17.0.2)
       '@mui/material': 5.17.1(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@types/react@17.0.75)(react-dom@17.0.2)(react@17.0.2)
       '@mui/utils': 5.17.1(@types/react@17.0.75)(react@17.0.2)
@@ -3886,7 +3886,7 @@ packages:
       react-date-range: 1.4.0(date-fns@2.30.0)(react@17.0.2)
       react-dom: 17.0.2(react@17.0.2)
       react-final-form: 6.5.9(final-form@4.20.10)(react@17.0.2)
-      react-intl: 5.25.1(@types/react@17.0.75)(react@17.0.2)(typescript@5.9.2)
+      react-intl: 7.1.11(@types/react@17.0.75)(react@17.0.2)(typescript@5.9.2)
     transitivePeerDependencies:
       - '@apollo/client'
       - '@emotion/react'
@@ -3916,7 +3916,7 @@ packages:
       use-constant: 1.1.1(react@17.0.2)
       uuid: 9.0.1
 
-  /@comet/admin-rte@7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(draft-js@0.11.7)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2):
+  /@comet/admin-rte@7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(draft-js@0.11.7)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@7.1.11)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2):
     resolution: {integrity: sha512-mKVuiJXzyonZDU/DDi3Ek4Mdu5hXNsVbsNT2V7OqCU4oTQgEFuUCuq5YkbU8pv3DK9R+SHOeajpKpSgNJNpvuw==}
     peerDependencies:
       '@mui/material': ^5.0.0
@@ -3927,7 +3927,7 @@ packages:
       react-final-form: ^6.3.1
       react-intl: ^5.0.0 || ^6.0.0
     dependencies:
-      '@comet/admin': 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
+      '@comet/admin': 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@7.1.11)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
       '@comet/admin-icons': 7.25.1(@mui/material@5.17.1)(react-dom@17.0.2)(react@17.0.2)
       '@mui/material': 5.17.1(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@types/react@17.0.75)(react-dom@17.0.2)(react@17.0.2)
       detect-browser: 5.3.0
@@ -3940,7 +3940,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       react-final-form: 6.5.9(final-form@4.20.10)(react@17.0.2)
-      react-intl: 5.25.1(@types/react@17.0.75)(react@17.0.2)(typescript@5.9.2)
+      react-intl: 7.1.11(@types/react@17.0.75)(react@17.0.2)(typescript@5.9.2)
     transitivePeerDependencies:
       - '@apollo/client'
       - '@emotion/react'
@@ -3972,7 +3972,7 @@ packages:
       - '@types/react'
       - react-dom
 
-  /@comet/admin@7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2):
+  /@comet/admin@7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@7.1.11)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2):
     resolution: {integrity: sha512-A8hDB+Shk1VxlEcBIdc7XqcSoZAwBbk727zdmG8pfOmjZWglRz71GmnnOwFwKZ8vUu0TieVP0QDF6a7+85xpRw==}
     peerDependencies:
       '@apollo/client': ^3.7.0
@@ -4025,7 +4025,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
       react-dropzone: 14.3.5(react@17.0.2)
       react-final-form: 6.5.9(final-form@4.20.10)(react@17.0.2)
-      react-intl: 5.25.1(@types/react@17.0.75)(react@17.0.2)(typescript@5.9.2)
+      react-intl: 7.1.11(@types/react@17.0.75)(react@17.0.2)(typescript@5.9.2)
       react-router: 5.3.4(react@17.0.2)
       react-router-dom: 5.3.4(react@17.0.2)
       use-constant: 1.1.1(react@17.0.2)
@@ -4034,7 +4034,7 @@ packages:
       - '@mui/system'
       - '@types/react'
 
-  /@comet/blocks-admin@7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2):
+  /@comet/blocks-admin@7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@7.1.11)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2):
     resolution: {integrity: sha512-rxzxgiXBsNFadotQV3lIl3JkI0rWSY91p9jTtd1/QlviMEwBwWjM6qqViIWDN7SHDnJOEhK2EWArp6VH6x9X+Q==}
     peerDependencies:
       '@mui/material': ^5.0.0
@@ -4046,7 +4046,7 @@ packages:
       react-router: ^5.0.0
       react-router-dom: ^5.0.0
     dependencies:
-      '@comet/admin': 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
+      '@comet/admin': 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@7.1.11)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
       '@comet/admin-icons': 7.25.1(@mui/material@5.17.1)(react-dom@17.0.2)(react@17.0.2)
       '@mui/lab': 5.0.0-alpha.176(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@types/react@17.0.75)(react-dom@17.0.2)(react@17.0.2)
       '@mui/material': 5.17.1(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@types/react@17.0.75)(react-dom@17.0.2)(react@17.0.2)
@@ -4056,7 +4056,7 @@ packages:
       react-dnd: 16.0.1(@types/node@22.16.2)(@types/react@17.0.75)(react@17.0.2)
       react-dom: 17.0.2(react@17.0.2)
       react-final-form: 6.5.9(final-form@4.20.10)(react@17.0.2)
-      react-intl: 5.25.1(@types/react@17.0.75)(react@17.0.2)(typescript@5.9.2)
+      react-intl: 7.1.11(@types/react@17.0.75)(react@17.0.2)(typescript@5.9.2)
       react-router: 5.3.4(react@17.0.2)
       react-router-dom: 5.3.4(react@17.0.2)
       rimraf: 3.0.2
@@ -4097,7 +4097,7 @@ packages:
       ts-node: 10.9.2(@types/node@22.16.2)(typescript@5.9.2)
     dev: true
 
-  /@comet/cms-admin@7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(draft-js@0.11.7)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2):
+  /@comet/cms-admin@7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(draft-js@0.11.7)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@7.1.11)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2):
     resolution: {integrity: sha512-HhNyvifCOknRnq9SqhHC8kb4uo2E4jq2T8NMQ0cJ9N6/IjuxyClSvAwHANpXwBHolil5DB85hr0a2EotYnbhhw==}
     hasBin: true
     peerDependencies:
@@ -4118,12 +4118,12 @@ packages:
       react-router-dom: ^5.0.0
     dependencies:
       '@apollo/client': 3.12.2(@types/react@17.0.75)(graphql@15.9.0)(react-dom@17.0.2)(react@17.0.2)
-      '@comet/admin': 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
-      '@comet/admin-date-time': 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
+      '@comet/admin': 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@7.1.11)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
+      '@comet/admin-date-time': 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@7.1.11)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
       '@comet/admin-icons': 7.25.1(@mui/material@5.17.1)(react-dom@17.0.2)(react@17.0.2)
-      '@comet/admin-rte': 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(draft-js@0.11.7)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
+      '@comet/admin-rte': 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(draft-js@0.11.7)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@7.1.11)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
       '@comet/admin-theme': 7.25.1(@mui/material@5.17.1)(@mui/system@5.17.1)(@types/react@17.0.75)(react-dom@17.0.2)(react@17.0.2)
-      '@comet/blocks-admin': 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
+      '@comet/blocks-admin': 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@7.1.11)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
       '@emotion/react': 11.11.3(@types/react@17.0.75)(react@17.0.2)
       '@emotion/styled': 11.11.0(@emotion/react@11.11.3)(@types/react@17.0.75)(react@17.0.2)
       '@graphql-tools/graphql-file-loader': 7.5.17(graphql@15.9.0)
@@ -4165,7 +4165,7 @@ packages:
       react-final-form-arrays: 3.1.4(final-form-arrays@3.1.0)(final-form@4.20.10)(react-final-form@6.5.9)(react@17.0.2)
       react-hotkeys-hook: 3.4.7(react-dom@17.0.2)(react@17.0.2)
       react-image-crop: 8.6.12(react@17.0.2)
-      react-intl: 5.25.1(@types/react@17.0.75)(react@17.0.2)(typescript@5.9.2)
+      react-intl: 7.1.11(@types/react@17.0.75)(react@17.0.2)(typescript@5.9.2)
       react-router: 5.3.4(react@17.0.2)
       react-router-dom: 5.3.4(react@17.0.2)
       react-split: 2.0.14(react@17.0.2)
@@ -4745,6 +4745,7 @@ packages:
     dependencies:
       '@formatjs/intl-localematcher': 0.2.25
       tslib: 2.8.1
+    dev: true
 
   /@formatjs/ecma402-abstract@1.18.2:
     resolution: {integrity: sha512-+QoPW4csYALsQIl8GbN14igZzDbuwzcpWrku9nyMXlaqAlwRBgl5V+p0vWMGFqHOw37czNXaP/lEk4wbLgcmtA==}
@@ -4759,8 +4760,16 @@ packages:
       tslib: 2.8.1
     dev: true
 
-  /@formatjs/fast-memoize@1.2.1:
-    resolution: {integrity: sha512-Rg0e76nomkz3vF9IPlKeV+Qynok0r7YZjL6syLz4/urSg0IbjPZCB/iYUMNsYA643gh4mgrX3T7KEIFIxJBQeg==}
+  /@formatjs/ecma402-abstract@2.3.4:
+    resolution: {integrity: sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==}
+    dependencies:
+      '@formatjs/fast-memoize': 2.2.7
+      '@formatjs/intl-localematcher': 0.6.1
+      decimal.js: 10.4.3
+      tslib: 2.8.1
+
+  /@formatjs/fast-memoize@2.2.7:
+    resolution: {integrity: sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==}
     dependencies:
       tslib: 2.8.1
 
@@ -4769,6 +4778,14 @@ packages:
     dependencies:
       '@formatjs/ecma402-abstract': 1.11.4
       '@formatjs/icu-skeleton-parser': 1.3.6
+      tslib: 2.8.1
+    dev: true
+
+  /@formatjs/icu-messageformat-parser@2.11.2:
+    resolution: {integrity: sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==}
+    dependencies:
+      '@formatjs/ecma402-abstract': 2.3.4
+      '@formatjs/icu-skeleton-parser': 1.8.14
       tslib: 2.8.1
 
   /@formatjs/icu-messageformat-parser@2.7.5:
@@ -4784,6 +4801,7 @@ packages:
     dependencies:
       '@formatjs/ecma402-abstract': 1.11.4
       tslib: 2.8.1
+    dev: true
 
   /@formatjs/icu-skeleton-parser@1.7.2:
     resolution: {integrity: sha512-nlIXVv280bjGW3ail5Np1+xgGKBnMhwQQIivgbk9xX0af8ESQO+y2VW9TOY7mCrs3WH786uVpZlLimXAlXH7SA==}
@@ -4792,24 +4810,17 @@ packages:
       tslib: 2.8.1
     dev: true
 
-  /@formatjs/intl-displaynames@5.4.3:
-    resolution: {integrity: sha512-4r12A3mS5dp5hnSaQCWBuBNfi9Amgx2dzhU4lTFfhSxgb5DOAiAbMpg6+7gpWZgl4ahsj3l2r/iHIjdmdXOE2Q==}
+  /@formatjs/icu-skeleton-parser@1.8.14:
+    resolution: {integrity: sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==}
     dependencies:
-      '@formatjs/ecma402-abstract': 1.11.4
-      '@formatjs/intl-localematcher': 0.2.25
-      tslib: 2.8.1
-
-  /@formatjs/intl-listformat@6.5.3:
-    resolution: {integrity: sha512-ozpz515F/+3CU+HnLi5DYPsLa6JoCfBggBSSg/8nOB5LYSFW9+ZgNQJxJ8tdhKYeODT+4qVHX27EeJLoxLGLNg==}
-    dependencies:
-      '@formatjs/ecma402-abstract': 1.11.4
-      '@formatjs/intl-localematcher': 0.2.25
+      '@formatjs/ecma402-abstract': 2.3.4
       tslib: 2.8.1
 
   /@formatjs/intl-localematcher@0.2.25:
     resolution: {integrity: sha512-YmLcX70BxoSopLFdLr1Ds99NdlTI2oWoLbaUW2M406lxOIPzE1KQhRz2fPUkq34xVZQaihCoU29h0KK7An3bhA==}
     dependencies:
       tslib: 2.8.1
+    dev: true
 
   /@formatjs/intl-localematcher@0.5.4:
     resolution: {integrity: sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==}
@@ -4817,20 +4828,23 @@ packages:
       tslib: 2.8.1
     dev: true
 
-  /@formatjs/intl@2.2.1(typescript@5.9.2):
-    resolution: {integrity: sha512-vgvyUOOrzqVaOFYzTf2d3+ToSkH2JpR7x/4U1RyoHQLmvEaTQvXJ7A2qm1Iy3brGNXC/+/7bUlc3lpH+h/LOJA==}
+  /@formatjs/intl-localematcher@0.6.1:
+    resolution: {integrity: sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==}
+    dependencies:
+      tslib: 2.8.1
+
+  /@formatjs/intl@3.1.6(typescript@5.9.2):
+    resolution: {integrity: sha512-tDkXnA4qpIFcDWac8CyVJq6oW8DR7W44QDUBsfXWIIJD/FYYen0QoH46W7XsVMFfPOVKkvbufjboZrrWbEfmww==}
     peerDependencies:
-      typescript: ^4.5
+      typescript: ^5.6.0
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@formatjs/ecma402-abstract': 1.11.4
-      '@formatjs/fast-memoize': 1.2.1
-      '@formatjs/icu-messageformat-parser': 2.1.0
-      '@formatjs/intl-displaynames': 5.4.3
-      '@formatjs/intl-listformat': 6.5.3
-      intl-messageformat: 9.13.0
+      '@formatjs/ecma402-abstract': 2.3.4
+      '@formatjs/fast-memoize': 2.2.7
+      '@formatjs/icu-messageformat-parser': 2.11.2
+      intl-messageformat: 10.7.16
       tslib: 2.8.1
       typescript: 5.9.2
 
@@ -5458,7 +5472,7 @@ packages:
     dependencies:
       '@graphql-tools/utils': 9.2.1(graphql@15.9.0)
       graphql: 15.9.0
-      tslib: 2.5.0
+      tslib: 2.8.1
 
   /@graphql-tools/merge@8.4.2(graphql@15.9.0):
     resolution: {integrity: sha512-XbrHAaj8yDuINph+sAfuq3QCZ/tKblrTLOpirK0+CAgNlZUCHs0Fa+xtMUURgwCVThLle1AF7svJCxFizygLsw==}
@@ -5467,7 +5481,7 @@ packages:
     dependencies:
       '@graphql-tools/utils': 9.2.1(graphql@15.9.0)
       graphql: 15.9.0
-      tslib: 2.6.2
+      tslib: 2.8.1
 
   /@graphql-tools/mock@8.7.20(graphql@15.9.0):
     resolution: {integrity: sha512-ljcHSJWjC/ZyzpXd5cfNhPI7YljRVvabKHPzKjEs5ElxWu2cdlLGvyNYepApXDsM/OJG/2xuhGM+9GWu5gEAPQ==}
@@ -5487,7 +5501,7 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 15.9.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /@graphql-tools/prisma-loader@7.2.72(@types/node@22.16.2)(graphql@15.9.0):
@@ -5530,7 +5544,7 @@ packages:
       '@ardatan/relay-compiler': 12.0.0(graphql@15.9.0)
       '@graphql-tools/utils': 9.2.1(graphql@15.9.0)
       graphql: 15.9.0
-      tslib: 2.4.1
+      tslib: 2.8.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -5556,7 +5570,7 @@ packages:
       '@graphql-tools/merge': 8.3.18(graphql@15.9.0)
       '@graphql-tools/utils': 9.2.1(graphql@15.9.0)
       graphql: 15.9.0
-      tslib: 2.5.0
+      tslib: 2.8.1
       value-or-promise: 1.0.12
 
   /@graphql-tools/schema@9.0.19(graphql@15.9.0):
@@ -5567,7 +5581,7 @@ packages:
       '@graphql-tools/merge': 8.4.2(graphql@15.9.0)
       '@graphql-tools/utils': 9.2.1(graphql@15.9.0)
       graphql: 15.9.0
-      tslib: 2.6.2
+      tslib: 2.8.1
       value-or-promise: 1.0.12
 
   /@graphql-tools/url-loader@7.17.18(@types/node@22.16.2)(graphql@15.9.0):
@@ -12147,7 +12161,6 @@ packages:
 
   /decimal.js@10.4.3:
     resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
-    dev: true
 
   /decode-uri-component@0.2.2:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
@@ -14916,12 +14929,12 @@ packages:
       tslib: 2.8.1
     dev: true
 
-  /intl-messageformat@9.13.0:
-    resolution: {integrity: sha512-7sGC7QnSQGa5LZP7bXLDhVDtQOeKGeBFGHF2Y8LVBwYZoQZCgWeKoPGTa5GMG8g/TzDgeXuYJQis7Ggiw2xTOw==}
+  /intl-messageformat@10.7.16:
+    resolution: {integrity: sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==}
     dependencies:
-      '@formatjs/ecma402-abstract': 1.11.4
-      '@formatjs/fast-memoize': 1.2.1
-      '@formatjs/icu-messageformat-parser': 2.1.0
+      '@formatjs/ecma402-abstract': 2.3.4
+      '@formatjs/fast-memoize': 2.2.7
+      '@formatjs/icu-messageformat-parser': 2.11.2
       tslib: 2.8.1
 
   /invariant@2.2.4:
@@ -15079,7 +15092,7 @@ packages:
   /is-lower-case@2.0.2:
     resolution: {integrity: sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /is-map@2.0.2:
@@ -15229,7 +15242,7 @@ packages:
   /is-upper-case@2.0.2:
     resolution: {integrity: sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /is-weakmap@2.0.1:
@@ -16957,7 +16970,7 @@ packages:
   /lower-case-first@2.0.2:
     resolution: {integrity: sha512-EVm/rR94FJTZi3zefZ82fLWab+GX14LJN4HrWBcuo6Evmsl9hEfnqxgcHCKb9q+mNf6EVdsjx/qucYFIIB84pg==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /lower-case@1.1.4:
@@ -16966,7 +16979,7 @@ packages:
   /lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   /lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
@@ -19188,48 +19201,44 @@ packages:
       prop-types: 15.8.1
       react: 17.0.2
 
-  /react-intl@5.25.1(@types/react@17.0.75)(react@17.0.2)(typescript@5.9.2):
-    resolution: {integrity: sha512-pkjdQDvpJROoXLMltkP/5mZb0/XqrqLoPGKUCfbdkP8m6U9xbK40K51Wu+a4aQqTEvEK5lHBk0fWzUV72SJ3Hg==}
+  /react-intl@7.1.11(@types/react@17.0.75)(react@17.0.2)(typescript@5.9.2):
+    resolution: {integrity: sha512-tnVoRCWvW5Ie2ikYSdPF7z3+880yCe/9xPmitFeRPw3RYDcCfR4m8ZYa4MBq19W4adt9Z+PQA4FaMBCJ7E+HCQ==}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.3.0 || 17 || 18
-      typescript: ^4.5
+      react: 16 || 17 || 18 || 19
+      typescript: ^5.6.0
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@formatjs/ecma402-abstract': 1.11.4
-      '@formatjs/icu-messageformat-parser': 2.1.0
-      '@formatjs/intl': 2.2.1(typescript@5.9.2)
-      '@formatjs/intl-displaynames': 5.4.3
-      '@formatjs/intl-listformat': 6.5.3
+      '@formatjs/ecma402-abstract': 2.3.4
+      '@formatjs/icu-messageformat-parser': 2.11.2
+      '@formatjs/intl': 3.1.6(typescript@5.9.2)
       '@types/hoist-non-react-statics': 3.3.5(@types/react@17.0.75)
       '@types/react': 17.0.75
       hoist-non-react-statics: 3.3.2
-      intl-messageformat: 9.13.0
+      intl-messageformat: 10.7.16
       react: 17.0.2
       tslib: 2.8.1
       typescript: 5.9.2
 
-  /react-intl@5.25.1(@types/react@18.3.12)(react@18.3.1)(typescript@5.9.2):
-    resolution: {integrity: sha512-pkjdQDvpJROoXLMltkP/5mZb0/XqrqLoPGKUCfbdkP8m6U9xbK40K51Wu+a4aQqTEvEK5lHBk0fWzUV72SJ3Hg==}
+  /react-intl@7.1.11(@types/react@18.3.12)(react@18.3.1)(typescript@5.9.2):
+    resolution: {integrity: sha512-tnVoRCWvW5Ie2ikYSdPF7z3+880yCe/9xPmitFeRPw3RYDcCfR4m8ZYa4MBq19W4adt9Z+PQA4FaMBCJ7E+HCQ==}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.3.0 || 17 || 18
-      typescript: ^4.5
+      react: 16 || 17 || 18 || 19
+      typescript: ^5.6.0
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@formatjs/ecma402-abstract': 1.11.4
-      '@formatjs/icu-messageformat-parser': 2.1.0
-      '@formatjs/intl': 2.2.1(typescript@5.9.2)
-      '@formatjs/intl-displaynames': 5.4.3
-      '@formatjs/intl-listformat': 6.5.3
+      '@formatjs/ecma402-abstract': 2.3.4
+      '@formatjs/icu-messageformat-parser': 2.11.2
+      '@formatjs/intl': 3.1.6(typescript@5.9.2)
       '@types/hoist-non-react-statics': 3.3.5(@types/react@18.3.12)
       '@types/react': 18.3.12
       hoist-non-react-statics: 3.3.2
-      intl-messageformat: 9.13.0
+      intl-messageformat: 10.7.16
       react: 18.3.1
       tslib: 2.8.1
       typescript: 5.9.2
@@ -20316,7 +20325,7 @@ packages:
   /sponge-case@1.0.1:
     resolution: {integrity: sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /sprintf-js@1.0.3:
@@ -20653,7 +20662,7 @@ packages:
   /swap-case@2.0.2:
     resolution: {integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /symbol-observable@1.2.0:
@@ -20825,7 +20834,7 @@ packages:
   /title-case@3.0.3:
     resolution: {integrity: sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
     dev: true
 
   /titleize@3.0.0:
@@ -21112,6 +21121,7 @@ packages:
 
   /tslib@2.4.1:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
+    dev: true
 
   /tslib@2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
@@ -21397,7 +21407,7 @@ packages:
   /upper-case-first@2.0.2:
     resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   /upper-case@1.1.3:
     resolution: {integrity: sha512-WRbjgmYzgXkCV7zNVpy5YgrHgbBv126rMALQQMrmzOVC4GM2waQ9x7xtm8VU+1yF2kWyPzI9zbZ48n4vSxwfSA==}
@@ -21405,7 +21415,7 @@ packages:
   /upper-case@2.0.2:
     resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
     dependencies:
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   /uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,10 +42,10 @@ importers:
         version: 2.8.8
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.16.2)(typescript@4.9.5)
+        version: 10.9.2(@types/node@22.16.2)(typescript@5.9.2)
       typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
+        specifier: ^5.8.3
+        version: 5.9.2
 
   demo/admin:
     dependencies:
@@ -150,7 +150,7 @@ importers:
         version: 6.5.9(final-form@4.20.10)(react@17.0.2)
       react-intl:
         specifier: ^5.25.1
-        version: 5.25.1(@types/react@17.0.75)(react@17.0.2)(typescript@4.9.5)
+        version: 5.25.1(@types/react@17.0.75)(react@17.0.2)(typescript@5.9.2)
       react-router:
         specifier: ^5.3.4
         version: 5.3.4(react@17.0.2)
@@ -163,7 +163,7 @@ importers:
         version: 7.25.1(ts-node@10.9.2)
       '@comet/eslint-config':
         specifier: ^7.21.1
-        version: 7.25.1(eslint@8.56.0)(next@14.2.25)(prettier@2.8.8)(typescript@4.9.5)
+        version: 7.25.1(eslint@8.56.0)(next@14.2.25)(prettier@2.8.8)(typescript@5.9.2)
       '@emotion/babel-plugin':
         specifier: ^11.0.0
         version: 11.11.0
@@ -256,10 +256,10 @@ importers:
         version: 3.3.4(webpack@5.94.0)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.16.2)(typescript@4.9.5)
+        version: 10.9.2(@types/node@22.16.2)(typescript@5.9.2)
       typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
+        specifier: ^5.8.3
+        version: 5.9.2
       webpack:
         specifier: ^5.0.0
         version: 5.94.0(webpack-cli@4.10.0)
@@ -416,13 +416,13 @@ importers:
     devDependencies:
       '@comet/eslint-config':
         specifier: ^7.21.1
-        version: 7.25.1(eslint@8.56.0)(prettier@2.8.8)(ts-jest@27.1.5)(typescript@4.9.5)
+        version: 7.25.1(eslint@8.56.0)(prettier@2.8.8)(ts-jest@27.1.5)(typescript@5.9.2)
       '@nestjs/cli':
         specifier: ^9.5.0
         version: 9.5.0
       '@nestjs/schematics':
         specifier: ^9.2.0
-        version: 9.2.0(chokidar@3.5.3)(typescript@4.9.5)
+        version: 9.2.0(typescript@5.9.2)
       '@nestjs/testing':
         specifier: ^9.4.3
         version: 9.4.3(@nestjs/common@9.4.3)(@nestjs/core@9.4.3)(@nestjs/platform-express@9.4.3)
@@ -467,19 +467,19 @@ importers:
         version: 2.8.8
       ts-jest:
         specifier: ^27.1.5
-        version: 27.1.5(@types/jest@27.5.2)(jest@27.5.1)(typescript@4.9.5)
+        version: 27.1.5(@types/jest@27.5.2)(jest@27.5.1)(typescript@5.9.2)
       ts-loader:
         specifier: ^8.4.0
-        version: 8.4.0(typescript@4.9.5)(webpack@5.94.0)
+        version: 8.4.0(typescript@5.9.2)(webpack@5.94.0)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.16.2)(typescript@4.9.5)
+        version: 10.9.2(@types/node@22.16.2)(typescript@5.9.2)
       tsconfig-paths:
         specifier: ^3.15.0
         version: 3.15.0
       typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
+        specifier: ^5.8.3
+        version: 5.9.2
 
   demo/campaign:
     dependencies:
@@ -545,7 +545,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       react-intl:
         specifier: ^5.25.1
-        version: 5.25.1(@types/react@18.3.12)(react@18.3.1)(typescript@4.9.5)
+        version: 5.25.1(@types/react@18.3.12)(react@18.3.1)(typescript@5.9.2)
       react-is:
         specifier: ^17.0.2
         version: 17.0.2
@@ -560,7 +560,7 @@ importers:
         version: 6.1.19(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.16.2)(typescript@4.9.5)
+        version: 10.9.2(@types/node@22.16.2)(typescript@5.9.2)
       zod:
         specifier: ^3.23.8
         version: 3.23.8
@@ -573,7 +573,7 @@ importers:
         version: 7.25.1(ts-node@10.9.2)
       '@comet/eslint-config':
         specifier: ^7.21.1
-        version: 7.25.1(eslint@8.56.0)(next@14.2.25)(prettier@2.8.8)(typescript@4.9.5)
+        version: 7.25.1(eslint@8.56.0)(next@14.2.25)(prettier@2.8.8)(typescript@5.9.2)
       '@formatjs/cli':
         specifier: ^4.8.4
         version: 4.8.4
@@ -638,8 +638,8 @@ importers:
         specifier: ^3.15.0
         version: 3.15.0
       typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
+        specifier: ^5.8.3
+        version: 5.9.2
 
   demo/site:
     dependencies:
@@ -690,7 +690,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       react-intl:
         specifier: ^5.25.1
-        version: 5.25.1(@types/react@18.3.12)(react@18.3.1)(typescript@4.9.5)
+        version: 5.25.1(@types/react@18.3.12)(react@18.3.1)(typescript@5.9.2)
       react-is:
         specifier: ^17.0.2
         version: 17.0.2
@@ -705,7 +705,7 @@ importers:
         version: 6.1.19(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.16.2)(typescript@4.9.5)
+        version: 10.9.2(@types/node@22.16.2)(typescript@5.9.2)
     devDependencies:
       '@babel/core':
         specifier: ^7.26.0
@@ -715,7 +715,7 @@ importers:
         version: 7.25.1(ts-node@10.9.2)
       '@comet/eslint-config':
         specifier: ^7.21.1
-        version: 7.25.1(eslint@8.56.0)(next@14.2.25)(prettier@2.8.8)(typescript@4.9.5)
+        version: 7.25.1(eslint@8.56.0)(next@14.2.25)(prettier@2.8.8)(typescript@5.9.2)
       '@formatjs/cli':
         specifier: ^4.8.4
         version: 4.8.4
@@ -780,8 +780,8 @@ importers:
         specifier: ^3.15.0
         version: 3.15.0
       typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
+        specifier: ^5.8.3
+        version: 5.9.2
 
   packages/admin:
     dependencies:
@@ -827,7 +827,7 @@ importers:
         version: 7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(draft-js@0.11.7)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2)
       '@comet/eslint-config':
         specifier: ^7.21.1
-        version: 7.25.1(eslint@8.56.0)(next@14.2.25)(prettier@2.8.8)(typescript@4.9.5)
+        version: 7.25.1(eslint@8.56.0)(next@14.2.25)(prettier@2.8.8)(typescript@5.9.2)
       '@emotion/react':
         specifier: ^11.9.3
         version: 11.11.3(@types/react@17.0.75)(react@17.0.2)
@@ -899,7 +899,7 @@ importers:
         version: 6.5.9(final-form@4.20.10)(react@17.0.2)
       react-intl:
         specifier: ^5.25.1
-        version: 5.25.1(@types/react@17.0.75)(react@17.0.2)(typescript@4.9.5)
+        version: 5.25.1(@types/react@17.0.75)(react@17.0.2)(typescript@5.9.2)
       react-router:
         specifier: ^5.3.4
         version: 5.3.4(react@17.0.2)
@@ -910,8 +910,8 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
+        specifier: ^5.8.3
+        version: 5.9.2
 
   packages/api:
     dependencies:
@@ -945,7 +945,7 @@ importers:
         version: 7.25.1(@kubernetes/client-node@0.18.1)(@mikro-orm/core@5.9.8)(@mikro-orm/migrations@5.9.8)(@mikro-orm/nestjs@5.2.3)(@mikro-orm/postgresql@5.9.8)(@nestjs/common@9.4.3)(@nestjs/core@9.4.3)(@nestjs/graphql@10.2.1)(@nestjs/platform-express@9.4.3)(class-validator@0.13.2)(express@4.21.2)(graphql@15.9.0)(nestjs-console@8.0.0)(rxjs@7.8.1)
       '@comet/eslint-config':
         specifier: ^7.21.1
-        version: 7.25.1(eslint@8.56.0)(prettier@2.8.8)(ts-jest@29.1.1)(typescript@4.9.5)
+        version: 7.25.1(eslint@8.56.0)(prettier@2.8.8)(ts-jest@29.1.1)(typescript@5.9.2)
       '@kubernetes/client-node':
         specifier: ^0.18.0
         version: 0.18.1
@@ -1044,13 +1044,13 @@ importers:
         version: 7.8.1
       ts-jest:
         specifier: ^29.0.5
-        version: 29.1.1(jest@29.7.0)(typescript@4.9.5)
+        version: 29.1.1(jest@29.7.0)(typescript@5.9.2)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.16.2)(typescript@4.9.5)
+        version: 10.9.2(@types/node@22.16.2)(typescript@5.9.2)
       typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
+        specifier: ^5.8.3
+        version: 5.9.2
       uuid:
         specifier: ^8.3.2
         version: 8.3.2
@@ -1065,7 +1065,7 @@ importers:
         version: 7.25.1(@types/react@18.3.12)(next@14.2.25)(react-dom@18.3.1)(react@18.3.1)(styled-components@6.1.19)
       '@comet/eslint-config':
         specifier: ^7.21.1
-        version: 7.25.1(eslint@8.56.0)(next@14.2.25)(prettier@2.8.8)(typescript@4.9.5)
+        version: 7.25.1(eslint@8.56.0)(next@14.2.25)(prettier@2.8.8)(typescript@5.9.2)
       '@luma-team/mjml-react':
         specifier: ^0.2.1
         version: 0.2.1(react-dom@18.3.1)(react@18.3.1)
@@ -1103,8 +1103,8 @@ importers:
         specifier: ^6.1.18
         version: 6.1.19(@types/react@18.3.12)(react-dom@18.3.1)(react@18.3.1)
       typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
+        specifier: ^5.8.3
+        version: 5.9.2
 
 packages:
 
@@ -3886,7 +3886,7 @@ packages:
       react-date-range: 1.4.0(date-fns@2.30.0)(react@17.0.2)
       react-dom: 17.0.2(react@17.0.2)
       react-final-form: 6.5.9(final-form@4.20.10)(react@17.0.2)
-      react-intl: 5.25.1(@types/react@17.0.75)(react@17.0.2)(typescript@4.9.5)
+      react-intl: 5.25.1(@types/react@17.0.75)(react@17.0.2)(typescript@5.9.2)
     transitivePeerDependencies:
       - '@apollo/client'
       - '@emotion/react'
@@ -3940,7 +3940,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       react-final-form: 6.5.9(final-form@4.20.10)(react@17.0.2)
-      react-intl: 5.25.1(@types/react@17.0.75)(react@17.0.2)(typescript@4.9.5)
+      react-intl: 5.25.1(@types/react@17.0.75)(react@17.0.2)(typescript@5.9.2)
     transitivePeerDependencies:
       - '@apollo/client'
       - '@emotion/react'
@@ -4025,7 +4025,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
       react-dropzone: 14.3.5(react@17.0.2)
       react-final-form: 6.5.9(final-form@4.20.10)(react@17.0.2)
-      react-intl: 5.25.1(@types/react@17.0.75)(react@17.0.2)(typescript@4.9.5)
+      react-intl: 5.25.1(@types/react@17.0.75)(react@17.0.2)(typescript@5.9.2)
       react-router: 5.3.4(react@17.0.2)
       react-router-dom: 5.3.4(react@17.0.2)
       use-constant: 1.1.1(react@17.0.2)
@@ -4056,7 +4056,7 @@ packages:
       react-dnd: 16.0.1(@types/node@22.16.2)(@types/react@17.0.75)(react@17.0.2)
       react-dom: 17.0.2(react@17.0.2)
       react-final-form: 6.5.9(final-form@4.20.10)(react@17.0.2)
-      react-intl: 5.25.1(@types/react@17.0.75)(react@17.0.2)(typescript@4.9.5)
+      react-intl: 5.25.1(@types/react@17.0.75)(react@17.0.2)(typescript@5.9.2)
       react-router: 5.3.4(react@17.0.2)
       react-router-dom: 5.3.4(react@17.0.2)
       rimraf: 3.0.2
@@ -4094,7 +4094,7 @@ packages:
     dependencies:
       commander: 9.5.0
       prettier: 2.8.8
-      ts-node: 10.9.2(@types/node@22.16.2)(typescript@4.9.5)
+      ts-node: 10.9.2(@types/node@22.16.2)(typescript@5.9.2)
     dev: true
 
   /@comet/cms-admin@7.25.1(@apollo/client@3.12.2)(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@mui/material@5.17.1)(@mui/system@5.17.1)(@mui/x-data-grid@5.17.26)(@types/react@17.0.75)(draft-js@0.11.7)(final-form@4.20.10)(graphql@15.9.0)(history@4.10.1)(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1)(react-dom@17.0.2)(react-final-form@6.5.9)(react-intl@5.25.1)(react-router-dom@5.3.4)(react-router@5.3.4)(react@17.0.2):
@@ -4165,7 +4165,7 @@ packages:
       react-final-form-arrays: 3.1.4(final-form-arrays@3.1.0)(final-form@4.20.10)(react-final-form@6.5.9)(react@17.0.2)
       react-hotkeys-hook: 3.4.7(react-dom@17.0.2)(react@17.0.2)
       react-image-crop: 8.6.12(react@17.0.2)
-      react-intl: 5.25.1(@types/react@17.0.75)(react@17.0.2)(typescript@4.9.5)
+      react-intl: 5.25.1(@types/react@17.0.75)(react@17.0.2)(typescript@5.9.2)
       react-router: 5.3.4(react@17.0.2)
       react-router-dom: 5.3.4(react@17.0.2)
       react-split: 2.0.14(react@17.0.2)
@@ -4319,7 +4319,7 @@ packages:
       - debug
     dev: true
 
-  /@comet/eslint-config@7.25.1(eslint@8.56.0)(next@14.2.25)(prettier@2.8.8)(typescript@4.9.5):
+  /@comet/eslint-config@7.25.1(eslint@8.56.0)(next@14.2.25)(prettier@2.8.8)(typescript@5.9.2):
     resolution: {integrity: sha512-0e+yc9L3VAb0ZcnHEMiwT31Xzm/qhs/GPwS7oretxvzjFy0t1vqqd8dRPMU/GpnlER3OnTut2uRIVGvbNrk8GA==}
     peerDependencies:
       eslint: '>= 8'
@@ -4332,10 +4332,10 @@ packages:
       '@calm/eslint-plugin-react-intl': 1.4.1
       '@comet/eslint-plugin': 7.25.1(eslint@8.56.0)
       '@next/eslint-plugin-next': 14.2.16
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.56.0)(typescript@4.9.5)
-      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@4.9.5)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.56.0)(typescript@5.9.2)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.9.2)
       eslint: 8.56.0
-      eslint-config-next: 14.2.16(eslint@8.56.0)(typescript@4.9.5)
+      eslint-config-next: 14.2.16(eslint@8.56.0)(typescript@5.9.2)
       eslint-config-prettier: 8.10.0(eslint@8.56.0)
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
       eslint-plugin-formatjs: 4.12.1(eslint@8.56.0)(ts-jest@29.1.1)
@@ -4357,7 +4357,7 @@ packages:
       - typescript
     dev: true
 
-  /@comet/eslint-config@7.25.1(eslint@8.56.0)(prettier@2.8.8)(ts-jest@27.1.5)(typescript@4.9.5):
+  /@comet/eslint-config@7.25.1(eslint@8.56.0)(prettier@2.8.8)(ts-jest@27.1.5)(typescript@5.9.2):
     resolution: {integrity: sha512-0e+yc9L3VAb0ZcnHEMiwT31Xzm/qhs/GPwS7oretxvzjFy0t1vqqd8dRPMU/GpnlER3OnTut2uRIVGvbNrk8GA==}
     peerDependencies:
       eslint: '>= 8'
@@ -4370,10 +4370,10 @@ packages:
       '@calm/eslint-plugin-react-intl': 1.4.1
       '@comet/eslint-plugin': 7.25.1(eslint@8.56.0)
       '@next/eslint-plugin-next': 14.2.16
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.56.0)(typescript@4.9.5)
-      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@4.9.5)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.56.0)(typescript@5.9.2)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.9.2)
       eslint: 8.56.0
-      eslint-config-next: 14.2.16(eslint@8.56.0)(typescript@4.9.5)
+      eslint-config-next: 14.2.16(eslint@8.56.0)(typescript@5.9.2)
       eslint-config-prettier: 8.10.0(eslint@8.56.0)
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
       eslint-plugin-formatjs: 4.12.1(eslint@8.56.0)(ts-jest@27.1.5)
@@ -4394,7 +4394,7 @@ packages:
       - typescript
     dev: true
 
-  /@comet/eslint-config@7.25.1(eslint@8.56.0)(prettier@2.8.8)(ts-jest@29.1.1)(typescript@4.9.5):
+  /@comet/eslint-config@7.25.1(eslint@8.56.0)(prettier@2.8.8)(ts-jest@29.1.1)(typescript@5.9.2):
     resolution: {integrity: sha512-0e+yc9L3VAb0ZcnHEMiwT31Xzm/qhs/GPwS7oretxvzjFy0t1vqqd8dRPMU/GpnlER3OnTut2uRIVGvbNrk8GA==}
     peerDependencies:
       eslint: '>= 8'
@@ -4407,10 +4407,10 @@ packages:
       '@calm/eslint-plugin-react-intl': 1.4.1
       '@comet/eslint-plugin': 7.25.1(eslint@8.56.0)
       '@next/eslint-plugin-next': 14.2.16
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.56.0)(typescript@4.9.5)
-      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@4.9.5)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.56.0)(typescript@5.9.2)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.9.2)
       eslint: 8.56.0
-      eslint-config-next: 14.2.16(eslint@8.56.0)(typescript@4.9.5)
+      eslint-config-next: 14.2.16(eslint@8.56.0)(typescript@5.9.2)
       eslint-config-prettier: 8.10.0(eslint@8.56.0)
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
       eslint-plugin-formatjs: 4.12.1(eslint@8.56.0)(ts-jest@29.1.1)
@@ -4817,7 +4817,7 @@ packages:
       tslib: 2.8.1
     dev: true
 
-  /@formatjs/intl@2.2.1(typescript@4.9.5):
+  /@formatjs/intl@2.2.1(typescript@5.9.2):
     resolution: {integrity: sha512-vgvyUOOrzqVaOFYzTf2d3+ToSkH2JpR7x/4U1RyoHQLmvEaTQvXJ7A2qm1Iy3brGNXC/+/7bUlc3lpH+h/LOJA==}
     peerDependencies:
       typescript: ^4.5
@@ -4832,7 +4832,7 @@ packages:
       '@formatjs/intl-listformat': 6.5.3
       intl-messageformat: 9.13.0
       tslib: 2.8.1
-      typescript: 4.9.5
+      typescript: 5.9.2
 
   /@formatjs/ts-transformer@3.13.11(ts-jest@27.1.5):
     resolution: {integrity: sha512-qOAGGUQC7GSMMaAFy2MAlC8REM58lUNi8W+VlRb57cDUpge46x2hP33Mzu5N1xmm6OCqDQTRXws5jEOcRI3C8Q==}
@@ -4847,9 +4847,9 @@ packages:
       '@types/node': 17.0.45
       chalk: 4.1.2
       json-stable-stringify: 1.1.1
-      ts-jest: 27.1.5(@types/jest@27.5.2)(jest@27.5.1)(typescript@4.9.5)
+      ts-jest: 27.1.5(@types/jest@27.5.2)(jest@27.5.1)(typescript@5.9.2)
       tslib: 2.8.1
-      typescript: 5.3.3
+      typescript: 5.9.2
     dev: true
 
   /@formatjs/ts-transformer@3.13.11(ts-jest@29.1.1):
@@ -4865,9 +4865,9 @@ packages:
       '@types/node': 17.0.45
       chalk: 4.1.2
       json-stable-stringify: 1.1.1
-      ts-jest: 29.1.1(jest@29.7.0)(typescript@4.9.5)
+      ts-jest: 29.1.1(jest@29.7.0)(typescript@5.9.2)
       tslib: 2.8.1
-      typescript: 5.3.3
+      typescript: 5.9.2
     dev: true
 
   /@formatjs/ts-transformer@3.2.1:
@@ -7034,6 +7034,20 @@ packages:
       jsonc-parser: 3.2.0
       pluralize: 8.0.0
       typescript: 4.9.5
+    transitivePeerDependencies:
+      - chokidar
+    dev: true
+
+  /@nestjs/schematics@9.2.0(typescript@5.9.2):
+    resolution: {integrity: sha512-wHpNJDPzM6XtZUOB3gW0J6mkFCSJilzCM3XrHI1o0C8vZmFE1snbmkIXNyoi1eV0Nxh1BMymcgz5vIMJgQtTqw==}
+    peerDependencies:
+      typescript: '>=4.3.5'
+    dependencies:
+      '@angular-devkit/core': 16.0.1(chokidar@3.5.3)
+      '@angular-devkit/schematics': 16.0.1(chokidar@3.5.3)
+      jsonc-parser: 3.2.0
+      pluralize: 8.0.0
+      typescript: 5.9.2
     transitivePeerDependencies:
       - chokidar
     dev: true
@@ -9634,7 +9648,7 @@ packages:
       '@types/yargs-parser': 21.0.3
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.56.0)(typescript@4.9.5):
+  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.56.0)(typescript@5.9.2):
     resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -9646,23 +9660,23 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.9.2)
       '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@8.56.0)(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@4.9.5)
+      '@typescript-eslint/type-utils': 5.62.0(eslint@8.56.0)(typescript@5.9.2)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@5.9.2)
       debug: 4.3.7(supports-color@9.4.0)
       eslint: 8.56.0
       graphemer: 1.4.0
       ignore: 5.3.0
       natural-compare-lite: 1.4.0
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
+      tsutils: 3.21.0(typescript@5.9.2)
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@4.9.5):
+  /@typescript-eslint/parser@5.62.0(eslint@8.56.0)(typescript@5.9.2):
     resolution: {integrity: sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -9674,10 +9688,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.2)
       debug: 4.3.7(supports-color@9.4.0)
       eslint: 8.56.0
-      typescript: 4.9.5
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9698,7 +9712,7 @@ packages:
       '@typescript-eslint/visitor-keys': 6.19.0
     dev: true
 
-  /@typescript-eslint/type-utils@5.62.0(eslint@8.56.0)(typescript@4.9.5):
+  /@typescript-eslint/type-utils@5.62.0(eslint@8.56.0)(typescript@5.9.2):
     resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -9708,12 +9722,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.2)
+      '@typescript-eslint/utils': 5.62.0(eslint@8.56.0)(typescript@5.9.2)
       debug: 4.3.7(supports-color@9.4.0)
       eslint: 8.56.0
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
+      tsutils: 3.21.0(typescript@5.9.2)
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -9728,7 +9742,7 @@ packages:
     engines: {node: ^16.0.0 || >=18.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.62.0(typescript@4.9.5):
+  /@typescript-eslint/typescript-estree@5.62.0(typescript@5.9.2):
     resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -9743,13 +9757,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@4.9.5)
-      typescript: 4.9.5
+      tsutils: 3.21.0(typescript@5.9.2)
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@6.19.0(typescript@5.3.3):
+  /@typescript-eslint/typescript-estree@6.19.0(typescript@5.9.2):
     resolution: {integrity: sha512-o/zefXIbbLBZ8YJ51NlkSAt2BamrK6XOmuxSR3hynMIzzyMY33KuJ9vuMdFSXW+H0tVvdF9qBPTHA91HDb4BIQ==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -9765,13 +9779,13 @@ packages:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.5.4
-      ts-api-utils: 1.0.3(typescript@5.3.3)
-      typescript: 5.3.3
+      ts-api-utils: 1.0.3(typescript@5.9.2)
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.62.0(eslint@8.56.0)(typescript@4.9.5):
+  /@typescript-eslint/utils@5.62.0(eslint@8.56.0)(typescript@5.9.2):
     resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -9782,7 +9796,7 @@ packages:
       '@types/semver': 7.5.6
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.9.2)
       eslint: 8.56.0
       eslint-scope: 5.1.1
       semver: 7.5.4
@@ -9791,7 +9805,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@6.19.0(eslint@8.56.0)(typescript@5.3.3):
+  /@typescript-eslint/utils@6.19.0(eslint@8.56.0)(typescript@5.9.2):
     resolution: {integrity: sha512-QR41YXySiuN++/dC9UArYOg4X86OAYP83OWTewpVx5ct1IZhjjgTLocj7QNxGhWoTqknsgpl7L+hGygCO+sdYw==}
     engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
@@ -9802,7 +9816,7 @@ packages:
       '@types/semver': 7.5.6
       '@typescript-eslint/scope-manager': 6.19.0
       '@typescript-eslint/types': 6.19.0
-      '@typescript-eslint/typescript-estree': 6.19.0(typescript@5.3.3)
+      '@typescript-eslint/typescript-estree': 6.19.0(typescript@5.9.2)
       eslint: 8.56.0
       semver: 7.5.4
     transitivePeerDependencies:
@@ -12792,7 +12806,7 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-next@14.2.16(eslint@8.56.0)(typescript@4.9.5):
+  /eslint-config-next@14.2.16(eslint@8.56.0)(typescript@5.9.2):
     resolution: {integrity: sha512-HOcnCJsyLXR7B8wmjaCgkTSpz+ijgOyAkP8OlvANvciP8PspBYFEBTmakNMxOf71fY0aKOm/blFIiKnrM4K03Q==}
     peerDependencies:
       eslint: ^7.23.0 || ^8.0.0
@@ -12803,8 +12817,8 @@ packages:
     dependencies:
       '@next/eslint-plugin-next': 14.2.16
       '@rushstack/eslint-patch': 1.7.0
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.56.0)(typescript@4.9.5)
-      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@4.9.5)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.56.0)(typescript@5.9.2)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.9.2)
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@8.56.0)
@@ -12812,7 +12826,7 @@ packages:
       eslint-plugin-jsx-a11y: 6.8.0(eslint@8.56.0)
       eslint-plugin-react: 7.33.2(eslint@8.56.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.56.0)
-      typescript: 4.9.5
+      typescript: 5.9.2
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - supports-color
@@ -12881,7 +12895,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.9.2)
       debug: 3.2.7
       eslint: 8.56.0
       eslint-import-resolver-node: 0.3.9
@@ -12899,13 +12913,13 @@ packages:
       '@formatjs/ts-transformer': 3.13.11(ts-jest@27.1.5)
       '@types/eslint': 8.56.2
       '@types/picomatch': 2.3.3
-      '@typescript-eslint/utils': 6.19.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/utils': 6.19.0(eslint@8.56.0)(typescript@5.9.2)
       emoji-regex: 10.3.0
       eslint: 8.56.0
       magic-string: 0.30.5
       picomatch: 2.3.1
       tslib: 2.6.2
-      typescript: 5.3.3
+      typescript: 5.9.2
       unicode-emoji-utils: 1.2.0
     transitivePeerDependencies:
       - supports-color
@@ -12921,13 +12935,13 @@ packages:
       '@formatjs/ts-transformer': 3.13.11(ts-jest@29.1.1)
       '@types/eslint': 8.56.2
       '@types/picomatch': 2.3.3
-      '@typescript-eslint/utils': 6.19.0(eslint@8.56.0)(typescript@5.3.3)
+      '@typescript-eslint/utils': 6.19.0(eslint@8.56.0)(typescript@5.9.2)
       emoji-regex: 10.3.0
       eslint: 8.56.0
       magic-string: 0.30.5
       picomatch: 2.3.1
       tslib: 2.6.2
-      typescript: 5.3.3
+      typescript: 5.9.2
       unicode-emoji-utils: 1.2.0
     transitivePeerDependencies:
       - supports-color
@@ -12944,7 +12958,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@4.9.5)
+      '@typescript-eslint/parser': 5.62.0(eslint@8.56.0)(typescript@5.9.2)
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
       array.prototype.flat: 1.3.2
@@ -13077,7 +13091,7 @@ packages:
       '@typescript-eslint/eslint-plugin':
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.56.0)(typescript@4.9.5)
+      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.56.0)(typescript@5.9.2)
       eslint: 8.56.0
       eslint-rule-composer: 0.3.0
     dev: true
@@ -15537,7 +15551,7 @@ packages:
       pretty-format: 27.5.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.2(@types/node@22.16.2)(typescript@4.9.5)
+      ts-node: 10.9.2(@types/node@22.16.2)(typescript@5.9.2)
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -15580,7 +15594,7 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.2(@types/node@22.16.2)(typescript@4.9.5)
+      ts-node: 10.9.2(@types/node@22.16.2)(typescript@5.9.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -19174,7 +19188,7 @@ packages:
       prop-types: 15.8.1
       react: 17.0.2
 
-  /react-intl@5.25.1(@types/react@17.0.75)(react@17.0.2)(typescript@4.9.5):
+  /react-intl@5.25.1(@types/react@17.0.75)(react@17.0.2)(typescript@5.9.2):
     resolution: {integrity: sha512-pkjdQDvpJROoXLMltkP/5mZb0/XqrqLoPGKUCfbdkP8m6U9xbK40K51Wu+a4aQqTEvEK5lHBk0fWzUV72SJ3Hg==}
     peerDependencies:
       '@types/react': '*'
@@ -19186,7 +19200,7 @@ packages:
     dependencies:
       '@formatjs/ecma402-abstract': 1.11.4
       '@formatjs/icu-messageformat-parser': 2.1.0
-      '@formatjs/intl': 2.2.1(typescript@4.9.5)
+      '@formatjs/intl': 2.2.1(typescript@5.9.2)
       '@formatjs/intl-displaynames': 5.4.3
       '@formatjs/intl-listformat': 6.5.3
       '@types/hoist-non-react-statics': 3.3.5(@types/react@17.0.75)
@@ -19195,9 +19209,9 @@ packages:
       intl-messageformat: 9.13.0
       react: 17.0.2
       tslib: 2.8.1
-      typescript: 4.9.5
+      typescript: 5.9.2
 
-  /react-intl@5.25.1(@types/react@18.3.12)(react@18.3.1)(typescript@4.9.5):
+  /react-intl@5.25.1(@types/react@18.3.12)(react@18.3.1)(typescript@5.9.2):
     resolution: {integrity: sha512-pkjdQDvpJROoXLMltkP/5mZb0/XqrqLoPGKUCfbdkP8m6U9xbK40K51Wu+a4aQqTEvEK5lHBk0fWzUV72SJ3Hg==}
     peerDependencies:
       '@types/react': '*'
@@ -19209,7 +19223,7 @@ packages:
     dependencies:
       '@formatjs/ecma402-abstract': 1.11.4
       '@formatjs/icu-messageformat-parser': 2.1.0
-      '@formatjs/intl': 2.2.1(typescript@4.9.5)
+      '@formatjs/intl': 2.2.1(typescript@5.9.2)
       '@formatjs/intl-displaynames': 5.4.3
       '@formatjs/intl-listformat': 6.5.3
       '@types/hoist-non-react-statics': 3.3.5(@types/react@18.3.12)
@@ -19218,7 +19232,7 @@ packages:
       intl-messageformat: 9.13.0
       react: 18.3.1
       tslib: 2.8.1
-      typescript: 4.9.5
+      typescript: 5.9.2
     dev: false
 
   /react-is@16.13.1:
@@ -20916,13 +20930,13 @@ packages:
     engines: {node: '>=12'}
     dev: true
 
-  /ts-api-utils@1.0.3(typescript@5.3.3):
+  /ts-api-utils@1.0.3(typescript@5.9.2):
     resolution: {integrity: sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==}
     engines: {node: '>=16.13.0'}
     peerDependencies:
       typescript: '>=4.2.0'
     dependencies:
-      typescript: 5.3.3
+      typescript: 5.9.2
     dev: true
 
   /ts-invariant@0.10.3:
@@ -20931,7 +20945,7 @@ packages:
     dependencies:
       tslib: 2.8.1
 
-  /ts-jest@27.1.5(@types/jest@27.5.2)(jest@27.5.1)(typescript@4.9.5):
+  /ts-jest@27.1.5(@types/jest@27.5.2)(jest@27.5.1)(typescript@5.9.2):
     resolution: {integrity: sha512-Xv6jBQPoBEvBq/5i2TeSG9tt/nqkbpcurrEG1b+2yfBrcJelOZF9Ml6dmyMh7bcW9JyFbRYpR5rxROSlBLTZHA==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     hasBin: true
@@ -20961,11 +20975,11 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.5.4
-      typescript: 4.9.5
+      typescript: 5.9.2
       yargs-parser: 20.2.9
     dev: true
 
-  /ts-jest@29.1.1(jest@29.7.0)(typescript@4.9.5):
+  /ts-jest@29.1.1(jest@29.7.0)(typescript@5.9.2):
     resolution: {integrity: sha512-D6xjnnbP17cC85nliwGiL+tpoKN0StpgE0TeOjXQTU6MVCfsB4v7aW05CgQ/1OywGb0x/oy9hHFnN+sczTiRaA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -20994,11 +21008,11 @@ packages:
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.5.4
-      typescript: 4.9.5
+      typescript: 5.9.2
       yargs-parser: 21.1.1
     dev: true
 
-  /ts-loader@8.4.0(typescript@4.9.5)(webpack@5.94.0):
+  /ts-loader@8.4.0(typescript@5.9.2)(webpack@5.94.0):
     resolution: {integrity: sha512-6nFY3IZ2//mrPc+ImY3hNWx1vCHyEhl6V+wLmL4CZcm6g1CqX7UKrkc6y0i4FwcfOhxyMPCfaEvh20f4r9GNpw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -21010,7 +21024,7 @@ packages:
       loader-utils: 2.0.4
       micromatch: 4.0.8
       semver: 7.5.4
-      typescript: 4.9.5
+      typescript: 5.9.2
       webpack: 5.94.0(webpack-cli@4.10.0)
     dev: true
 
@@ -21024,7 +21038,7 @@ packages:
       '@ts-morph/common': 0.17.0
       code-block-writer: 11.0.3
 
-  /ts-node@10.9.2(@types/node@22.16.2)(typescript@4.9.5):
+  /ts-node@10.9.2(@types/node@22.16.2)(typescript@5.9.2):
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
     peerDependencies:
@@ -21050,7 +21064,7 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.9.5
+      typescript: 5.9.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
@@ -21111,14 +21125,14 @@ packages:
   /tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  /tsutils@3.21.0(typescript@4.9.5):
+  /tsutils@3.21.0(typescript@5.9.2):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.9.5
+      typescript: 5.9.2
     dev: true
 
   /tunnel-agent@0.6.0:
@@ -21230,12 +21244,12 @@ packages:
     resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
     engines: {node: '>=4.2.0'}
     hasBin: true
+    dev: true
 
-  /typescript@5.3.3:
-    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+  /typescript@5.9.2:
+    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
     hasBin: true
-    dev: true
 
   /ua-parser-js@0.7.37:
     resolution: {integrity: sha512-xV8kqRKM+jhMvcHWUKthV9fNebIzrNy//2O9ZwWcfiBFR5f25XVZPLlEajk/sf3Ra15V92isyQqnIEXRDaZWEA==}


### PR DESCRIPTION
Comet v8 Preparation: Switch from @comet/cms-site to @comet/site-nextjs 

See: https://docs.comet-dxp.com/docs/migration-guide/migration-from-v7-to-v8/#step-3-switch-from-cometcms-site-to-cometsite-nextjs-pr-3

-   [ ] Depends on: https://github.com/vivid-planet/comet-brevo-module/pull/338

Task: https://vivid-planet.atlassian.net/browse/COM-2219