### PR TITLE
Fix block transformation logic

### DIFF
--- a/.changeset/honest-berries-lie.md
+++ b/.changeset/honest-berries-lie.md
@@ -1,0 +1,5 @@
+---
+"@comet/brevo-api": patch
+---
+
+Fix block transformation logic. This resolves issues with invisible blocks not being displayed and ensures proper resolution of image URLs.

--- a/packages/api/src/email-campaign/email-campaigns.service.ts
+++ b/packages/api/src/email-campaign/email-campaigns.service.ts
@@ -45,7 +45,11 @@ export class EmailCampaignsService {
     }
 
     async saveEmailCampaignInBrevo(campaign: EmailCampaignInterface, scheduledAt?: Date): Promise<EmailCampaignInterface> {
-        const content = await this.blockTransformerService.transformToPlain(campaign.content);
+        const content = await this.blockTransformerService.transformToPlain(campaign.content, {
+            includeInvisibleContent: false,
+            previewDamUrls: false,
+            relativeDamUrls: true,
+        });
 
         const brevoConfig = await this.brevoConfigRepository.findOneOrFail({ scope: campaign.scope });
 


### PR DESCRIPTION
## Description
This change fixes that invisible blocks are shown.
Furthermore, image urls are correctly resolved. Before the preview-url was sent

With this change, no workaround in the newsletter-site is needed.

I already fixed this with this PR(https://github.com/vivid-planet/comet-brevo-module/pull/82), but I think we accidentally reverted it again.


